### PR TITLE
fix: correct RDS Valkey webhook registration and failover defaults

### DIFF
--- a/config/crd/bases/rds.valkey.buf.red_valkeys.yaml
+++ b/config/crd/bases/rds.valkey.buf.red_valkeys.yaml
@@ -700,8 +700,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1071,7 +1071,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -1394,7 +1394,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This is an alpha field and requires enabling the
+                      This field depends on the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -2307,8 +2307,8 @@ spec:
                               most preferred is the one with the greatest sum of weights, i.e.
                               for each node that meets all of the scheduling requirements (resource
                               request, requiredDuringScheduling anti-affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                               node(s) with the highest sum are the most preferred.
                             items:
                               description: The weights of all of the matched WeightedPodAffinityTerm
@@ -2677,7 +2677,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -2986,7 +2986,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.

--- a/config/crd/bases/valkey.buf.red_clusters.yaml
+++ b/config/crd/bases/valkey.buf.red_clusters.yaml
@@ -635,8 +635,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1060,7 +1060,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -1400,7 +1400,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This is an alpha field and requires enabling the
+                      This field depends on the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.

--- a/config/crd/bases/valkey.buf.red_failovers.yaml
+++ b/config/crd/bases/valkey.buf.red_failovers.yaml
@@ -678,8 +678,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1044,7 +1044,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -1356,7 +1356,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This is an alpha field and requires enabling the
+                      This field depends on the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.
@@ -2271,8 +2271,8 @@ spec:
                               most preferred is the one with the greatest sum of weights, i.e.
                               for each node that meets all of the scheduling requirements (resource
                               request, requiredDuringScheduling anti-affinity expressions, etc.),
-                              compute a sum by iterating through the elements of this field and adding
-                              "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                              compute a sum by iterating through the elements of this field and subtracting
+                              "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                               node(s) with the highest sum are the most preferred.
                             items:
                               description: The weights of all of the matched WeightedPodAffinityTerm
@@ -2641,7 +2641,7 @@ spec:
                               Claims lists the names of resources, defined in spec.resourceClaims,
                               that are used by this container.
 
-                              This is an alpha field and requires enabling the
+                              This field depends on the
                               DynamicResourceAllocation feature gate.
 
                               This field is immutable. It can only be set for containers.
@@ -2950,7 +2950,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.

--- a/config/crd/bases/valkey.buf.red_sentinels.yaml
+++ b/config/crd/bases/valkey.buf.red_sentinels.yaml
@@ -683,8 +683,8 @@ spec:
                           most preferred is the one with the greatest sum of weights, i.e.
                           for each node that meets all of the scheduling requirements (resource
                           request, requiredDuringScheduling anti-affinity expressions, etc.),
-                          compute a sum by iterating through the elements of this field and adding
-                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          compute a sum by iterating through the elements of this field and subtracting
+                          "weight" from the sum if the node has pods which matches the corresponding podAffinityTerm; the
                           node(s) with the highest sum are the most preferred.
                         items:
                           description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1049,7 +1049,7 @@ spec:
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
 
-                          This is an alpha field and requires enabling the
+                          This field depends on the
                           DynamicResourceAllocation feature gate.
 
                           This field is immutable. It can only be set for containers.
@@ -1342,7 +1342,7 @@ spec:
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
 
-                      This is an alpha field and requires enabling the
+                      This field depends on the
                       DynamicResourceAllocation feature gate.
 
                       This field is immutable. It can only be set for containers.

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,12 +10,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /mutate-rds-inst-buf-red-v1alpha1-inst
+      path: /mutate-rds-valkey-buf-red-v1alpha1-valkey
   failurePolicy: Fail
   name: mvalkey-v1alpha1.kb.io
   rules:
   - apiGroups:
-    - rds.inst.buf.red
+    - rds.valkey.buf.red
     apiVersions:
     - v1alpha1
     operations:
@@ -57,12 +57,12 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-rds-inst-buf-red-v1alpha1-inst
+      path: /validate-rds-valkey-buf-red-v1alpha1-valkey
   failurePolicy: Fail
   name: vvalkey-v1alpha1.kb.io
   rules:
   - apiGroups:
-    - rds.inst.buf.red
+    - rds.valkey.buf.red
     apiVersions:
     - v1alpha1
     operations:

--- a/internal/webhook/rds/v1alpha1/valkey_webhook.go
+++ b/internal/webhook/rds/v1alpha1/valkey_webhook.go
@@ -55,7 +55,7 @@ func SetupValkeyWebhookWithManager(mgr ctrl.Manager) error {
 		Complete()
 }
 
-// +kubebuilder:webhook:path=/mutate-rds-inst-buf-red-v1alpha1-inst,mutating=true,failurePolicy=fail,sideEffects=None,groups=rds.inst.buf.red,resources=valkeys,verbs=create;update,versions=v1alpha1,name=mvalkey-v1alpha1.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/mutate-rds-valkey-buf-red-v1alpha1-valkey,mutating=true,failurePolicy=fail,sideEffects=None,groups=rds.valkey.buf.red,resources=valkeys,verbs=create;update,versions=v1alpha1,name=mvalkey-v1alpha1.kb.io,admissionReviewVersions=v1
 
 // ValkeyCustomDefaulter struct is responsible for setting default values on the custom resource of the
 // Kind inst when those are created or updated.
@@ -118,6 +118,7 @@ func (d *ValkeyCustomDefaulter) Default(ctx context.Context, obj runtime.Object)
 				ReplicasOfShard: 2,
 			}
 		}
+		inst.Spec.Replicas.Shards = 1
 		if inst.Spec.Sentinel == nil {
 			inst.Spec.Sentinel = &v1alpha1.SentinelSettings{}
 		}
@@ -158,7 +159,7 @@ func (d *ValkeyCustomDefaulter) Default(ctx context.Context, obj runtime.Object)
 	return nil
 }
 
-// +kubebuilder:webhook:path=/validate-rds-inst-buf-red-v1alpha1-inst,mutating=false,failurePolicy=fail,sideEffects=None,groups=rds.inst.buf.red,resources=valkeys,verbs=create;update,versions=v1alpha1,name=vvalkey-v1alpha1.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-rds-valkey-buf-red-v1alpha1-valkey,mutating=false,failurePolicy=fail,sideEffects=None,groups=rds.valkey.buf.red,resources=valkeys,verbs=create;update,versions=v1alpha1,name=vvalkey-v1alpha1.kb.io,admissionReviewVersions=v1
 
 // ValkeyCustomValidator struct is responsible for validating the inst resource
 // when it is created, updated, or deleted.


### PR DESCRIPTION
Two bugs in the RDS Valkey admission webhook:

1. Webhook annotations referenced the wrong API group (rds.inst.buf.red instead of rds.valkey.buf.red), causing both the mutating and validating webhooks to never fire for Valkey CR operations. This meant the sentinel access serviceType was never propagated from spec.access.serviceType to spec.sentinel.access.serviceType, resulting in sentinel services always being ClusterIP even when NodePort was requested.

2. For ValkeyFailover arch, spec.replicas.shards was only defaulted to 1 when spec.replicas was nil. If the user provided a Replicas object with only ReplicasOfShard set, Shards defaulted to 0 and the validating webhook would reject the CR. Fixed by always enforcing Shards=1 for failover, matching the existing ValkeyReplica behavior.