### PR TITLE
ci: skip secret-dependent steps for PRs from forks

### DIFF
--- a/.github/workflows/pr-pipeline.yaml
+++ b/.github/workflows/pr-pipeline.yaml
@@ -33,6 +33,7 @@ jobs:
       run: go install github.com/mattn/goveralls@latest
 
     - name: Send coverage
+      if: github.event.pull_request.head.repo.full_name == github.repository
       env:
         COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
       run: goveralls -coverprofile=coverage.txt -service=github
@@ -41,7 +42,7 @@ jobs:
     name: Build and push Docker image
     permissions:
       contents: write
-    if: "!startsWith(github.head_ref, 'dependabot/')"
+    if: "!startsWith(github.head_ref, 'dependabot/') && github.event.pull_request.head.repo.full_name == github.repository"
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Summary

- PRs opened from forks (e.g. #91) can't access repository secrets or write-scoped tokens, so `Send coverage` (needs `COVERALLS_REPO_TOKEN`) and the entire `Build and push Docker image` job (needs `GH_TOKEN` to push to ghcr.io and commit `Chart.yaml`) always fail on them.
- Gate both on `github.event.pull_request.head.repo.full_name == github.repository` so fork PRs skip them cleanly while unit tests still run.
- Behavior for PRs from branches in this repo is unchanged.

## Test plan

- [ ] Open this PR (from a same-repo branch): `Send coverage` and the build job should both run as before.
- [ ] After merge, re-run CI on #91 (a fork PR): unit tests run; coverage upload and Docker build are skipped (green-skipped, not failed).

Refs: #91

Generated with [Claude Code](https://claude.ai/code)