### PR TITLE
fix: render version-conditional configmap directives via SafeVersion

### DIFF
--- a/charts/valkey-operator/Chart.yaml
+++ b/charts/valkey-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: valkey-operator
 description: A Helm chart for deploying the Valkey Operator on Kubernetes
 type: application
 version: 0.1.0
-appVersion: "latest"
+appVersion: "v1.1.1"
 keywords:
   - valkey
   - redis

--- a/internal/builder/aclbuilder/acl_test.go
+++ b/internal/builder/aclbuilder/acl_test.go
@@ -77,6 +77,10 @@ func (m *mockInstance) Version() version.ValkeyVersion {
 	return version.DefaultValKeyVersion
 }
 
+func (m *mockInstance) SafeVersion() version.ValkeyVersion {
+	return m.Version()
+}
+
 func (m *mockInstance) IsReady() bool {
 	return true
 }

--- a/internal/builder/certbuilder/cert_test.go
+++ b/internal/builder/certbuilder/cert_test.go
@@ -75,6 +75,10 @@ func (m *mockInstance) Version() version.ValkeyVersion {
 	return version.DefaultValKeyVersion
 }
 
+func (m *mockInstance) SafeVersion() version.ValkeyVersion {
+	return m.Version()
+}
+
 func (m *mockInstance) IsReady() bool {
 	return true
 }

--- a/internal/builder/clusterbuilder/configmap.go
+++ b/internal/builder/clusterbuilder/configmap.go
@@ -65,7 +65,7 @@ func buildValkeyConfigs(cluster types.ClusterInstance) (string, error) {
 	var (
 		buffer            bytes.Buffer
 		keys              = make([]string, 0, len(cr.Spec.CustomConfigs))
-		innerValkeyConfig = cluster.Version().CustomConfigs(core.ValkeyCluster)
+		innerValkeyConfig = cluster.SafeVersion().CustomConfigs(core.ValkeyCluster)
 		configMap         = lo.Assign(cr.Spec.CustomConfigs, innerValkeyConfig)
 	)
 

--- a/internal/builder/clusterbuilder/configmap_test.go
+++ b/internal/builder/clusterbuilder/configmap_test.go
@@ -99,6 +99,10 @@ func (m *MockClusterInstance) Version() version.ValkeyVersion {
 	return m.valkeyVer
 }
 
+func (m *MockClusterInstance) SafeVersion() version.ValkeyVersion {
+	return m.valkeyVer
+}
+
 // Arch returns the architecture of the cluster
 func (m *MockClusterInstance) Arch() core.Arch {
 	return core.ValkeyCluster

--- a/internal/builder/failoverbuilder/configmap.go
+++ b/internal/builder/failoverbuilder/configmap.go
@@ -45,7 +45,7 @@ func GenerateConfigMap(inst types.FailoverInstance) (*corev1.ConfigMap, error) {
 	var (
 		customConfig      = rf.Spec.CustomConfigs
 		keys              = make([]string, 0, len(rf.Spec.CustomConfigs))
-		innerValkeyConfig = inst.Version().CustomConfigs(core.ValkeyFailover)
+		innerValkeyConfig = inst.SafeVersion().CustomConfigs(core.ValkeyFailover)
 		configMap         = lo.Assign(rf.Spec.CustomConfigs, innerValkeyConfig)
 	)
 

--- a/internal/builder/sentinelbuilder/configmap.go
+++ b/internal/builder/sentinelbuilder/configmap.go
@@ -26,7 +26,6 @@ import (
 	"github.com/chideat/valkey-operator/internal/builder"
 	"github.com/chideat/valkey-operator/internal/util"
 	"github.com/chideat/valkey-operator/pkg/types"
-	"github.com/chideat/valkey-operator/pkg/version"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -52,8 +51,7 @@ func GenerateSentinelConfigMap(inst types.SentinelInstance) (*corev1.ConfigMap, 
 	defaultConfig["tcp-keepalive"] = "300"
 	defaultConfig["tcp-backlog"] = "511"
 
-	version, _ := version.ParseValkeyVersionFromImage(sen.Spec.Image)
-	innerValkeyConfig := version.CustomConfigs(core.ValkeySentinel)
+	innerValkeyConfig := inst.SafeVersion().CustomConfigs(core.ValkeySentinel)
 	defaultConfig = lo.Assign(defaultConfig, innerValkeyConfig)
 
 	for k, v := range sen.Spec.CustomConfigs {

--- a/internal/builder/sentinelbuilder/statefulset_test.go
+++ b/internal/builder/sentinelbuilder/statefulset_test.go
@@ -50,7 +50,8 @@ func (m *mockSentinelInstance) DeepCopyObject() runtime.Object   { return m.Sent
 func (m *mockSentinelInstance) NamespacedName() client.ObjectKey {
 	return client.ObjectKeyFromObject(m.Sentinel)
 }
-func (m *mockSentinelInstance) Version() version.ValkeyVersion { return version.ValkeyVersion("7.2") }
+func (m *mockSentinelInstance) Version() version.ValkeyVersion     { return version.ValkeyVersion("7.2") }
+func (m *mockSentinelInstance) SafeVersion() version.ValkeyVersion { return version.ValkeyVersion("7.2") }
 func (m *mockSentinelInstance) IsReady() bool                  { return true }
 func (m *mockSentinelInstance) Restart(ctx context.Context, annotationKeyVal ...string) error {
 	return nil

--- a/internal/ops/failover/actor/actor_update_config_test.go
+++ b/internal/ops/failover/actor/actor_update_config_test.go
@@ -56,7 +56,8 @@ func (m *mockFailoverInstance) DeepCopyObject() runtime.Object   { return m.Fail
 func (m *mockFailoverInstance) NamespacedName() client.ObjectKey {
 	return client.ObjectKeyFromObject(m.Failover)
 }
-func (m *mockFailoverInstance) Version() version.ValkeyVersion { return version.ValkeyVersion("7.2") }
+func (m *mockFailoverInstance) Version() version.ValkeyVersion     { return version.ValkeyVersion("7.2") }
+func (m *mockFailoverInstance) SafeVersion() version.ValkeyVersion { return version.ValkeyVersion("7.2") }
 func (m *mockFailoverInstance) IsReady() bool                  { return true }
 func (m *mockFailoverInstance) Restart(ctx context.Context, annotationKeyVal ...string) error {
 	return m.restartErr

--- a/internal/ops/sentinel/actor/actor_ensure_resource_test.go
+++ b/internal/ops/sentinel/actor/actor_ensure_resource_test.go
@@ -54,7 +54,8 @@ func (m *mockSentinelInstance) DeepCopyObject() runtime.Object   { return m.Sent
 func (m *mockSentinelInstance) NamespacedName() client.ObjectKey {
 	return client.ObjectKeyFromObject(m.Sentinel)
 }
-func (m *mockSentinelInstance) Version() version.ValkeyVersion { return version.ValkeyVersion("7.2") }
+func (m *mockSentinelInstance) Version() version.ValkeyVersion     { return version.ValkeyVersion("7.2") }
+func (m *mockSentinelInstance) SafeVersion() version.ValkeyVersion { return version.ValkeyVersion("7.2") }
 func (m *mockSentinelInstance) IsReady() bool                  { return true }
 func (m *mockSentinelInstance) Restart(ctx context.Context, annotationKeyVal ...string) error {
 	return nil

--- a/internal/valkey/cluster/cluster.go
+++ b/internal/valkey/cluster/cluster.go
@@ -417,6 +417,20 @@ func (c *ValkeyCluster) Version() version.ValkeyVersion {
 	}
 }
 
+// SafeVersion returns min(target version, every running node's CurrentVersion).
+// Used by ConfigMap rendering to avoid emitting directives that the still-old
+// pods of an in-progress upgrade cannot parse.
+func (c *ValkeyCluster) SafeVersion() version.ValkeyVersion {
+	if c == nil {
+		return version.ValkeyVersionUnknown
+	}
+	versions := []version.ValkeyVersion{c.Version()}
+	for _, node := range c.Nodes() {
+		versions = append(versions, node.CurrentVersion())
+	}
+	return version.MinKnown(versions...)
+}
+
 func (c *ValkeyCluster) Shards() []types.ClusterShard {
 	if c == nil {
 		return nil

--- a/internal/valkey/failover/failover.go
+++ b/internal/valkey/failover/failover.go
@@ -291,6 +291,19 @@ func (s *Failover) Version() version.ValkeyVersion {
 	}
 }
 
+// SafeVersion returns min(target version, every running node's CurrentVersion).
+// See types.Instance.SafeVersion for rationale.
+func (s *Failover) SafeVersion() version.ValkeyVersion {
+	if s == nil {
+		return version.ValkeyVersionUnknown
+	}
+	versions := []version.ValkeyVersion{s.Version()}
+	for _, node := range s.Nodes() {
+		versions = append(versions, node.CurrentVersion())
+	}
+	return version.MinKnown(versions...)
+}
+
 func (s *Failover) Masters() []types.ValkeyNode {
 	if s == nil || s.replication == nil {
 		return nil

--- a/internal/valkey/sentinel/sentinel.go
+++ b/internal/valkey/sentinel/sentinel.go
@@ -181,6 +181,19 @@ func (s *ValkeySentinel) Version() version.ValkeyVersion {
 	return ver
 }
 
+// SafeVersion returns min(target version, every running node's CurrentVersion).
+// See types.Instance.SafeVersion for rationale.
+func (s *ValkeySentinel) SafeVersion() version.ValkeyVersion {
+	if s == nil {
+		return version.ValkeyVersionUnknown
+	}
+	versions := []version.ValkeyVersion{s.Version()}
+	for _, node := range s.Nodes() {
+		versions = append(versions, node.CurrentVersion())
+	}
+	return version.MinKnown(versions...)
+}
+
 func (s *ValkeySentinel) Definition() *v1alpha1.Sentinel {
 	if s == nil {
 		return nil

--- a/pkg/types/instance.go
+++ b/pkg/types/instance.go
@@ -55,6 +55,15 @@ type Instance interface {
 	Object
 
 	Arch() core.Arch
+	// SafeVersion returns the lowest version among the desired (target) image
+	// version and every running pod's CurrentVersion. Use it when rendering
+	// version-conditional config (e.g. directives only valid in newer Valkey
+	// versions) to avoid crash-looping a pod that restarts on the old image
+	// before the StatefulSet rollout reaches it.
+	//
+	// Nodes reporting an unknown/empty version are ignored. When no known
+	// node version is available (initial bootstrap), returns Version().
+	SafeVersion() version.ValkeyVersion
 	// Issuer custom cert issuer
 	Issuer() *certmetav1.ObjectReference
 	Users() Users

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -93,6 +93,22 @@ func (v ValkeyVersion) Compare(other ValkeyVersion) int {
 	return 0
 }
 
+// MinKnown returns the lowest non-empty version among the inputs.
+// Empty (Unknown) versions are ignored. If all inputs are empty,
+// returns ValkeyVersionUnknown.
+func MinKnown(versions ...ValkeyVersion) ValkeyVersion {
+	var min ValkeyVersion
+	for _, v := range versions {
+		if v == ValkeyVersionUnknown {
+			continue
+		}
+		if min == ValkeyVersionUnknown || v.Compare(min) < 0 {
+			min = v
+		}
+	}
+	return min
+}
+
 // ParseVersion
 func ParseValkeyVersion(v string) (ValkeyVersion, error) {
 	ver, err := semver.NewVersion(v)

--- a/pkg/version/version_test.go
+++ b/pkg/version/version_test.go
@@ -250,3 +250,64 @@ func TestValkeyVersion_Compare(t *testing.T) {
 		})
 	}
 }
+
+func TestMinKnown(t *testing.T) {
+tests := []struct {
+name string
+args []ValkeyVersion
+want ValkeyVersion
+}{
+{
+name: "no inputs",
+args: nil,
+want: ValkeyVersionUnknown,
+},
+{
+name: "all unknown",
+args: []ValkeyVersion{ValkeyVersionUnknown, "", ""},
+want: ValkeyVersionUnknown,
+},
+{
+name: "single known",
+args: []ValkeyVersion{"7.2"},
+want: "7.2",
+},
+{
+name: "skips unknown, returns the only known",
+args: []ValkeyVersion{ValkeyVersionUnknown, "8.0", ""},
+want: "8.0",
+},
+{
+name: "lowest among multiple known",
+args: []ValkeyVersion{"8.0", "7.2", "8.1"},
+want: "7.2",
+},
+{
+name: "lowest with unknown mixed in",
+args: []ValkeyVersion{"8.0", "", "6.2", "7.2", ValkeyVersionUnknown},
+want: "6.2",
+},
+{
+name: "duplicates",
+args: []ValkeyVersion{"7.2", "7.2", "7.2"},
+want: "7.2",
+},
+{
+name: "target plus newer running pods (rolling forward)",
+args: []ValkeyVersion{"8.0", "8.0", "8.0"},
+want: "8.0",
+},
+{
+name: "target newer than some pods (in-progress upgrade)",
+args: []ValkeyVersion{"8.0", "7.2", "8.0"},
+want: "7.2",
+},
+}
+for _, tt := range tests {
+t.Run(tt.name, func(t *testing.T) {
+if got := MinKnown(tt.args...); got != tt.want {
+t.Errorf("MinKnown() = %q, want %q", got, tt.want)
+}
+})
+}
+}


### PR DESCRIPTION
When a Valkey cluster/failover/sentinel is upgrading, the operator wrote target-version-only directives into the ConfigMap before all pods were rolled to the new image. If a pod restarted on the old image before the StatefulSet update reached it, the server could crash with a 'Bad directive' fatal config error.

CustomConfigs() currently emits no version-gated keys, so the bug is latent today; this change hardens the same code path that already broke production for the redis-operator and prevents the class of failure once any version-conditional directive is added.

- pkg/types/instance.go: add SafeVersion() to Instance
- pkg/version/version.go: add MinKnown helper (skips empty, returns lowest)
- internal/valkey/{cluster,failover,sentinel}: implement SafeVersion at the instance level, reusing each node's existing CurrentVersion()
- internal/builder/{cluster,failover,sentinel}builder/configmap.go: derive CustomConfigs from inst.SafeVersion() instead of inst.Version()
- mocks updated to satisfy interface