### PR TITLE
docs: refresh supported Valkey/Kubernetes version matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,14 +48,16 @@ For detailed installation and configuration instructions, see the [User Guide](.
 
 ## Supported Versions
 
-| Version | K8s Versions | Supported |
-|---------|:-------------|-----------|
-| 7.2.x   | 1.31         | Yes       |
-|         | 1.32         | Yes       |
-| 8.0.x   | 1.31         | Yes       |
-|         | 1.32         | Yes       |
-| 8.1.x   | 1.31         | Yes       |
-|         | 1.32         | Yes       |
+| Valkey Version | Kubernetes Versions | Status   |
+|----------------|---------------------|----------|
+| 7.2.x          | 1.31, 1.32, 1.33    | Stable   |
+| 8.0.x          | 1.31, 1.32, 1.33    | Stable   |
+| 8.1.x          | 1.31, 1.32, 1.33    | Stable   |
+| 8.2.x          | 1.33                | Stable   |
+| 9.0.x          | 1.33                | Stable   |
+
+> Valkey 9.1 is currently a release candidate; the API enum accepts it for
+> early evaluation, but it is not part of the supported matrix yet.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -53,11 +53,13 @@ For detailed installation and configuration instructions, see the [User Guide](.
 | 7.2.x          | 1.31, 1.32, 1.33    | Stable   |
 | 8.0.x          | 1.31, 1.32, 1.33    | Stable   |
 | 8.1.x          | 1.31, 1.32, 1.33    | Stable   |
-| 8.2.x          | 1.33                | Stable   |
 | 9.0.x          | 1.33                | Stable   |
+| 9.1.x          | 1.33                | Preview  |
 
-> Valkey 9.1 is currently a release candidate; the API enum accepts it for
-> early evaluation, but it is not part of the supported matrix yet.
+> Valkey 9.1 is still an upstream release candidate. It has been validated
+> on K8s 1.33 and is exposed for evaluation, but is not recommended for
+> production. Valkey 8.2 has not been validated and is therefore not part
+> of the supported matrix, even though the API enum still accepts it.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ For detailed installation and configuration instructions, see the [User Guide](.
 
 > Valkey 9.1 is still an upstream release candidate. It has been validated
 > on K8s 1.33 and is exposed for evaluation, but is not recommended for
-> production. Valkey 8.2 has not been validated and is therefore not part
-> of the supported matrix, even though the API enum still accepts it.
+> production.
 
 ## Documentation
 

--- a/api/rds/v1alpha1/valkey_types.go
+++ b/api/rds/v1alpha1/valkey_types.go
@@ -55,9 +55,9 @@ type ValkeyExporter struct {
 // ValkeySpec defines the desired state of Valkey
 type ValkeySpec struct {
 	// Version specifies the Valkey version to deploy.
-	// Stable: 7.2, 8.0, 8.1, 8.2, 9.0
+	// Stable: 7.2, 8.0, 8.1, 9.0
 	// Preview/RC (not recommended for production): 9.1
-	// +kubebuilder:validation:Enum="7.2";"8.0";"8.1";"8.2";"9.0";"9.1"
+	// +kubebuilder:validation:Enum="7.2";"8.0";"8.1";"9.0";"9.1"
 	Version string `json:"version"`
 
 	// Arch supports cluster, sentinel

--- a/config/crd/bases/rds.valkey.buf.red_valkeys.yaml
+++ b/config/crd/bases/rds.valkey.buf.red_valkeys.yaml
@@ -3419,13 +3419,12 @@ spec:
               version:
                 description: |-
                   Version specifies the Valkey version to deploy.
-                  Stable: 7.2, 8.0, 8.1, 8.2, 9.0
+                  Stable: 7.2, 8.0, 8.1, 9.0
                   Preview/RC (not recommended for production): 9.1
                 enum:
                 - "7.2"
                 - "8.0"
                 - "8.1"
-                - "8.2"
                 - "9.0"
                 - "9.1"
                 type: string

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,11 +52,16 @@ spec:
 
 ## Supported Versions
 
-| Valkey Version | Kubernetes | Status |
-|---------------|------------|---------|
-| 7.2.x | 1.31, 1.32 | ✅ Supported |
-| 8.0.x | 1.31, 1.32 | ✅ Supported |
-| 8.1.x | 1.31, 1.32 | ✅ Supported |
+| Valkey Version | Kubernetes       | Status        |
+|----------------|------------------|---------------|
+| 7.2.x          | 1.31, 1.32, 1.33 | ✅ Supported  |
+| 8.0.x          | 1.31, 1.32, 1.33 | ✅ Supported  |
+| 8.1.x          | 1.31, 1.32, 1.33 | ✅ Supported  |
+| 8.2.x          | 1.33             | ✅ Supported  |
+| 9.0.x          | 1.33             | ✅ Supported  |
+
+> Valkey 9.1 is currently a release candidate; the API enum accepts it for
+> evaluation but it is not part of the supported matrix.
 
 ## Examples by Use Case
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,8 +62,7 @@ spec:
 
 > Valkey 9.1 is still an upstream release candidate. It has been validated
 > on K8s 1.33 and is exposed for evaluation, but it is not recommended for
-> production. Valkey 8.2 has not been validated and is therefore not part
-> of the supported matrix, even though the API enum still accepts it.
+> production.
 
 ## Examples by Use Case
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,11 +57,13 @@ spec:
 | 7.2.x          | 1.31, 1.32, 1.33 | ✅ Supported  |
 | 8.0.x          | 1.31, 1.32, 1.33 | ✅ Supported  |
 | 8.1.x          | 1.31, 1.32, 1.33 | ✅ Supported  |
-| 8.2.x          | 1.33             | ✅ Supported  |
 | 9.0.x          | 1.33             | ✅ Supported  |
+| 9.1.x          | 1.33             | 🧪 Preview    |
 
-> Valkey 9.1 is currently a release candidate; the API enum accepts it for
-> evaluation but it is not part of the supported matrix.
+> Valkey 9.1 is still an upstream release candidate. It has been validated
+> on K8s 1.33 and is exposed for evaluation, but it is not recommended for
+> production. Valkey 8.2 has not been validated and is therefore not part
+> of the supported matrix, even though the API enum still accepts it.
 
 ## Examples by Use Case
 

--- a/docs/api/rds-v1alpha1-valkey.md
+++ b/docs/api/rds-v1alpha1-valkey.md
@@ -22,7 +22,7 @@ status:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `version` | string | Valkey version to use (supported: "7.2", "8.0", "8.1", "8.2", "9.0"; preview: "9.1") |
+| `version` | string | Valkey version to use. Supported (stable): `"7.2"`, `"8.0"`, `"8.1"`, `"8.2"`, `"9.0"`. The API enum also accepts `"9.1"` for early evaluation, but it is currently an upstream release candidate and is not part of the supported matrix. |
 | `arch` | core.Arch | Architecture (`cluster`, `failover`, `replica`) |
 | `replicas` | *ValkeyReplicas | Desired number of replicas for Valkey |
 | `resources` | corev1.ResourceRequirements | Resource requirements |

--- a/docs/api/rds-v1alpha1-valkey.md
+++ b/docs/api/rds-v1alpha1-valkey.md
@@ -22,7 +22,7 @@ status:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `version` | string | Valkey version to use. Supported (stable): `"7.2"`, `"8.0"`, `"8.1"`, `"9.0"`. Preview (validated on K8s 1.33, upstream release candidate): `"9.1"`. The API enum also accepts `"8.2"`, but that version has not been validated and is not part of the supported matrix. |
+| `version` | string | Valkey version to use. Supported (stable): `"7.2"`, `"8.0"`, `"8.1"`, `"9.0"`. Preview (validated on K8s 1.33, upstream release candidate): `"9.1"`. |
 | `arch` | core.Arch | Architecture (`cluster`, `failover`, `replica`) |
 | `replicas` | *ValkeyReplicas | Desired number of replicas for Valkey |
 | `resources` | corev1.ResourceRequirements | Resource requirements |

--- a/docs/api/rds-v1alpha1-valkey.md
+++ b/docs/api/rds-v1alpha1-valkey.md
@@ -22,7 +22,7 @@ status:
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `version` | string | Valkey version to use. Supported (stable): `"7.2"`, `"8.0"`, `"8.1"`, `"8.2"`, `"9.0"`. The API enum also accepts `"9.1"` for early evaluation, but it is currently an upstream release candidate and is not part of the supported matrix. |
+| `version` | string | Valkey version to use. Supported (stable): `"7.2"`, `"8.0"`, `"8.1"`, `"9.0"`. Preview (validated on K8s 1.33, upstream release candidate): `"9.1"`. The API enum also accepts `"8.2"`, but that version has not been validated and is not part of the supported matrix. |
 | `arch` | core.Arch | Architecture (`cluster`, `failover`, `replica`) |
 | `replicas` | *ValkeyReplicas | Desired number of replicas for Valkey |
 | `resources` | corev1.ResourceRequirements | Resource requirements |

--- a/docs/guides/operator-overview.md
+++ b/docs/guides/operator-overview.md
@@ -69,9 +69,7 @@ Valkey Operator is a production-grade Kubernetes operator that automates the dep
 
 > Valkey 9.1 is still an upstream release candidate. It has been validated
 > on K8s 1.33 and is exposed for evaluation, but it is not recommended for
-> production workloads. Valkey 8.2 has not been validated and is therefore
-> not part of the supported matrix, even though the API enum still accepts
-> it.
+> production workloads.
 
 ## Use Cases
 

--- a/docs/guides/operator-overview.md
+++ b/docs/guides/operator-overview.md
@@ -64,12 +64,14 @@ Valkey Operator is a production-grade Kubernetes operator that automates the dep
 | 7.2.x          | 1.31, 1.32, 1.33    | ✅ Stable  |
 | 8.0.x          | 1.31, 1.32, 1.33    | ✅ Stable  |
 | 8.1.x          | 1.31, 1.32, 1.33    | ✅ Stable  |
-| 8.2.x          | 1.33                | ✅ Stable  |
 | 9.0.x          | 1.33                | ✅ Stable  |
+| 9.1.x          | 1.33                | 🧪 Preview |
 
-> Valkey 9.1 is currently a release candidate. The API enum accepts it for
-> early experimentation, but it is not part of the supported matrix and is
-> not recommended for production.
+> Valkey 9.1 is still an upstream release candidate. It has been validated
+> on K8s 1.33 and is exposed for evaluation, but it is not recommended for
+> production workloads. Valkey 8.2 has not been validated and is therefore
+> not part of the supported matrix, even though the API enum still accepts
+> it.
 
 ## Use Cases
 

--- a/docs/guides/operator-overview.md
+++ b/docs/guides/operator-overview.md
@@ -59,14 +59,17 @@ Valkey Operator is a production-grade Kubernetes operator that automates the dep
 
 ## Supported Valkey Versions
 
-| Valkey Version | Kubernetes Versions | Status |
-|----------------|-------------------|---------|
-| 7.2.x | 1.31, 1.32 | ✅ Stable |
-| 8.0.x | 1.31, 1.32 | ✅ Stable |
-| 8.1.x | 1.31, 1.32 | ✅ Stable |
-| 8.2.x | 1.32, 1.33 | ✅ Stable |
-| 9.0.x | 1.32, 1.33 | ✅ Stable |
-| 9.1.x | 1.32, 1.33 | Preview |
+| Valkey Version | Kubernetes Versions | Status     |
+|----------------|---------------------|------------|
+| 7.2.x          | 1.31, 1.32, 1.33    | ✅ Stable  |
+| 8.0.x          | 1.31, 1.32, 1.33    | ✅ Stable  |
+| 8.1.x          | 1.31, 1.32, 1.33    | ✅ Stable  |
+| 8.2.x          | 1.33                | ✅ Stable  |
+| 9.0.x          | 1.33                | ✅ Stable  |
+
+> Valkey 9.1 is currently a release candidate. The API enum accepts it for
+> early experimentation, but it is not part of the supported matrix and is
+> not recommended for production.
 
 ## Use Cases
 


### PR DESCRIPTION
## Summary

- Drop `"8.2"` from the rds Valkey `version` kubebuilder enum and regenerate the CRD. The 8.2 release was never validated and was documented as out-of-matrix; removing it from the enum makes the API itself reject it on create/update.
- Refresh the supported-versions tables in `README.md`, `docs/README.md`, `docs/guides/operator-overview.md`, and `docs/api/rds-v1alpha1-valkey.md` to match what was actually validated:
  - Stable: Valkey 7.2 / 8.0 / 8.1 on Kubernetes 1.31, 1.32, 1.33.
  - Stable: Valkey 9.0 on Kubernetes 1.33.
  - Preview: Valkey 9.1 on Kubernetes 1.33 — upstream release candidate, validated but not recommended for production.

## Notes

- The Helm-bundled CRDs under `charts/valkey-operator/crds/` are stale relative to `config/crd/bases/` for multiple unrelated reasons (they predate Valkey 9.0 / 9.1 entirely). Not addressed in this PR.

## Test plan

- [x] `make manifests` — CRD regenerates cleanly
- [x] `go build ./...`
- [x] `go test ./api/rds/... ./pkg/version/...`
- [ ] GitHub markdown render check after push