### PR TITLE
fix: cluster data-loss, graceful-failover & webhook fixes + full e2e coverage

### DIFF
--- a/charts/valkey-operator/Chart.yaml
+++ b/charts/valkey-operator/Chart.yaml
@@ -3,7 +3,7 @@ name: valkey-operator
 description: A Helm chart for deploying the Valkey Operator on Kubernetes
 type: application
 version: 0.1.0
-appVersion: "latest"
+appVersion: "v1.1.1"
 keywords:
   - valkey
   - redis

--- a/cmd/helper/commands/cluster/command.go
+++ b/cmd/helper/commands/cluster/command.go
@@ -151,11 +151,6 @@ func NewCommand(ctx context.Context) *cli.Command {
 						Usage: "Configmap name prefix",
 						Value: "sync-",
 					},
-					&cli.StringFlag{
-						Name:    "shard-id",
-						Usage:   "Shard ID for cluster shard",
-						EnvVars: []string{"SHARD_ID"},
-					},
 				},
 				Action: func(c *cli.Context) error {
 					logger := commands.NewLogger(c).WithName("Heal")

--- a/cmd/helper/commands/cluster/heal.go
+++ b/cmd/helper/commands/cluster/heal.go
@@ -44,7 +44,6 @@ type HealOptions struct {
 	Workspace  string
 	TargetName string
 	Prefix     string
-	ShardID    string
 	NodeFile   string
 }
 
@@ -56,7 +55,6 @@ func Heal(ctx context.Context, c *cli.Context, client *kubernetes.Clientset, log
 		Workspace:  c.String("workspace"),
 		TargetName: c.String("config-name"),
 		Prefix:     c.String("prefix"),
-		ShardID:    c.String("shard-id"),
 		NodeFile:   path.Join(c.String("workspace"), c.String("config-name")),
 	}
 
@@ -70,10 +68,7 @@ func Heal(ctx context.Context, c *cli.Context, client *kubernetes.Clientset, log
 		logger.Error(err, "nit nodes.conf failed")
 		return err
 	}
-	if data, err = fixClusterNodesConf(data, logger, opts); err != nil {
-		logger.Error(err, "fix nodes.conf failed")
-		return err
-	}
+	data = fixClusterNodesConf(data)
 
 	// persistent
 	nodeFileBak := opts.NodeFile + ".bak"
@@ -110,8 +105,10 @@ func initClusterNodesConf(ctx context.Context, client *kubernetes.Clientset, log
 		isUpdated = true
 	}
 	if len(data) == 0 {
-		// if nodes.conf is empty, custom node-id and shard-id
-		data = generateValkeyCluterNodeRecord(opts.Namespace, opts.PodName, opts.ShardID)
+		// if nodes.conf is empty, seed only a deterministic node-id so this pod
+		// keeps a stable identity across restarts. Do NOT seed a shard-id: it is
+		// valkey's to assign once this node replicates its primary.
+		data = generateValkeyCluterNodeRecord(opts.Namespace, opts.PodName)
 		isUpdated = true
 	}
 	if isUpdated && len(data) > 0 {
@@ -120,9 +117,12 @@ func initClusterNodesConf(ctx context.Context, client *kubernetes.Clientset, log
 	return data, nil
 }
 
-func fixClusterNodesConf(data []byte, logger logr.Logger, opts *HealOptions) ([]byte, error) {
+// fixClusterNodesConf sanitizes a recovered nodes.conf: it drops lines
+// corrupted by a valkey crash and normalizes the trailing epoch line. It
+// deliberately preserves every node's shard-id as valkey wrote it — shard-id
+// is a valkey-owned property and must not be rewritten by the operator.
+func fixClusterNodesConf(data []byte) []byte {
 	var (
-		shardId   = opts.ShardID
 		lines     []string
 		epochLine string
 	)
@@ -160,66 +160,7 @@ func fixClusterNodesConf(data []byte, logger logr.Logger, opts *HealOptions) ([]
 		// ignore epoch line
 	}
 
-	data = []byte(strings.Join(lines, "\n"))
-	if shardId == "" {
-		return data, nil
-	}
-
-	// verify shard id
-	lines = lines[0:0]
-	nodes, err := valkey.ParseNodes(string(data))
-	if err != nil {
-		logger.Error(err, "parse nodes failed")
-		return nil, err
-	}
-	selfNode := nodes.Self()
-	masterNodes := map[string]*valkey.ClusterNode{}
-	for _, node := range nodes.Masters() {
-		if node.Id == selfNode.Id ||
-			(selfNode.Role == valkey.MasterRole && node.MasterId == selfNode.Id) ||
-			(selfNode.Role == valkey.SlaveRole && node.Id == selfNode.MasterId) {
-			continue
-		}
-		masterNodes[node.Id] = node
-	}
-
-	for _, node := range nodes {
-		line := node.Raw()
-		if node.Id == selfNode.Id ||
-			(selfNode.Role == valkey.MasterRole && node.MasterId == selfNode.Id) ||
-			(selfNode.Role == valkey.SlaveRole && node.Id == selfNode.MasterId) {
-
-			if oldShardId := node.AuxFields.ShardID; oldShardId != shardId {
-				if oldShardId != "" {
-					line = strings.ReplaceAll(line, fmt.Sprintf("shard-id=%s", oldShardId), fmt.Sprintf("shard-id=%s", shardId))
-				} else {
-					line = strings.ReplaceAll(line, node.AuxFields.Raw(), fmt.Sprintf("%s,,tls-port=0,shard-id=%s", node.AuxFields.Raw(), shardId))
-				}
-			}
-			line = strings.ReplaceAll(line, ",nofailover", "")
-			lines = append(lines, line)
-		}
-	}
-	for _, master := range masterNodes {
-		isAllReplicasInSameShard := true
-		replicas := nodes.Replicas(master.Id)
-		for _, replica := range replicas {
-			if master.AuxFields.ShardID != replica.AuxFields.ShardID {
-				isAllReplicasInSameShard = false
-			}
-		}
-		if isAllReplicasInSameShard {
-			lines = append(lines, master.Raw())
-			for _, replica := range replicas {
-				lines = append(lines, replica.Raw())
-			}
-		}
-	}
-
-	if len(lines) > 0 && epochLine != "" {
-		lines = append(lines, epochLine)
-	}
-	return []byte(strings.Join(lines, "\n")), nil
+	return []byte(strings.Join(lines, "\n"))
 }
 
 func healCluster(c *cli.Context, ctx context.Context, client *kubernetes.Clientset, data []byte, logger logr.Logger) error {
@@ -341,15 +282,16 @@ func healCluster(c *cli.Context, ctx context.Context, client *kubernetes.Clients
 	return nil
 }
 
-func generateValkeyCluterNodeRecord(namespace, podName, shardId string) []byte {
-	tpl := `%s :0@0%s myself,master - 0 0 0 connected
+func generateValkeyCluterNodeRecord(namespace, podName string) []byte {
+	// Seed a deterministic node-id only. shard-id is intentionally omitted so
+	// valkey assigns it when this node replicates its primary (a pre-written
+	// shard-id makes an empty replica look like an empty primary to peers,
+	// which valkey 9.1 stale-packet detection permanently rejects).
+	tpl := `%s :0@0 myself,master - 0 0 0 connected
 vars currentEpoch 0 lastVoteEpoch 0`
-	if shardId != "" {
-		shardId = fmt.Sprintf(",,tls-port=0,shard-id=%s", shardId)
-	}
 
 	nodeId := fmt.Sprintf("%x", sha1.Sum(fmt.Appendf([]byte{}, "%s/%s", namespace, podName))) // #nosec G401
-	return fmt.Appendf([]byte{}, tpl, nodeId, shardId)
+	return fmt.Appendf([]byte{}, tpl, nodeId)
 }
 
 func getPodsOfShard(ctx context.Context, c *cli.Context, client *kubernetes.Clientset, logger logr.Logger) (pods []corev1.Pod, err error) {

--- a/cmd/helper/commands/cluster/heal.go
+++ b/cmd/helper/commands/cluster/heal.go
@@ -406,7 +406,12 @@ func doValkeyFailover(ctx context.Context, cli valkey.ValkeyClient, action Failo
 		return err
 	}
 
-	for range 3 {
+	// A failover election needs up to 2x cluster-node-timeout (default 15s)
+	// to collect votes, and masters refuse to vote again within the same
+	// window. Observe long enough for a full election round (plus one
+	// cooldown-blocked round) to finish — re-issuing CLUSTER FAILOVER too
+	// early resets the in-flight election and starves it of votes forever.
+	for range 14 {
 		logger.Info("check failover in 5s")
 		time.Sleep(time.Second * 5)
 

--- a/cmd/helper/commands/cluster/heal.go
+++ b/cmd/helper/commands/cluster/heal.go
@@ -406,12 +406,17 @@ func doValkeyFailover(ctx context.Context, cli valkey.ValkeyClient, action Failo
 		return err
 	}
 
-	// A failover election needs up to 2x cluster-node-timeout (default 15s)
-	// to collect votes, and masters refuse to vote again within the same
-	// window. Observe long enough for a full election round (plus one
-	// cooldown-blocked round) to finish — re-issuing CLUSTER FAILOVER too
-	// early resets the in-flight election and starves it of votes forever.
-	for range 14 {
+	// A plain manual failover coordinates with the master within
+	// 2x cluster-node-timeout (30s at the default 15s); a forced failover
+	// runs a vote election that can additionally be blocked by the masters'
+	// re-vote cooldown of the same length. Observe accordingly — re-issuing
+	// CLUSTER FAILOVER too early resets the in-flight election and starves
+	// it of votes forever.
+	waitRounds := 7 // 35s: plain manual failover window
+	if action == ForceFailoverAction {
+		waitRounds = 14 // 70s: election round + one cooldown-blocked round
+	}
+	for range waitRounds {
 		logger.Info("check failover in 5s")
 		time.Sleep(time.Second * 5)
 

--- a/cmd/helper/commands/cluster/heal_test.go
+++ b/cmd/helper/commands/cluster/heal_test.go
@@ -17,186 +17,103 @@ limitations under the License.
 package cluster
 
 import (
-	"context"
 	"reflect"
 	"sort"
 	"strings"
 	"testing"
-
-	"github.com/go-logr/logr"
 )
 
-func Test_portClusterNodesConf(t *testing.T) {
-	type args struct {
-		ctx    context.Context
-		data   []byte
-		logger logr.Logger
-		opts   *HealOptions
-	}
+func Test_fixClusterNodesConf(t *testing.T) {
 	tests := []struct {
-		name    string
-		args    args
-		want    []byte
-		wantErr bool
+		name string
+		data []byte
+		want []byte
 	}{
 		{
-			name: "new init node",
-			args: args{
-				ctx: context.Background(),
-				data: []byte(`267600f4b192a940a20759aa0ebeee22f41d69e6 :0@0,shard-id=8a6d146963271fcd409b36704c86650827ef73a1 myself,master - 0 0 0 connected
+			// A freshly seeded node carries a node-id but no shard-id; it must
+			// pass through untouched (the operator must not inject a shard-id).
+			name: "new init node without shard-id preserved",
+			data: []byte(`267600f4b192a940a20759aa0ebeee22f41d69e6 :0@0 myself,master - 0 0 0 connected
 vars currentEpoch 0 lastVoteEpoch 0`),
-				logger: logr.Discard(),
-				opts: &HealOptions{
-					Namespace:  "default",
-					PodName:    "drc-c77-0-0",
-					Workspace:  "/data",
-					TargetName: "nodes.conf",
-					Prefix:     "sync-",
-					ShardID:    "8a6d146963271fcd409b36704c86650827ef73a1",
-					NodeFile:   "/data/nodes.conf",
-				},
-			},
-			want: []byte(`267600f4b192a940a20759aa0ebeee22f41d69e6 :0@0,shard-id=8a6d146963271fcd409b36704c86650827ef73a1 myself,master - 0 0 0 connected
+			want: []byte(`267600f4b192a940a20759aa0ebeee22f41d69e6 :0@0 myself,master - 0 0 0 connected
 vars currentEpoch 0 lastVoteEpoch 0`),
-			wantErr: false,
 		},
 		{
-			name: "6 nodes",
-			args: args{
-				ctx: context.Background(),
-				data: []byte(`f89575a0d78cdc25b5ea1886bb88f1d979026c7d 192.168.132.183:32295@31500 slave c8b765997335f66f892ca6840f7f0b6df8200638 0 1709546093510 1 connected
-c8b765997335f66f892ca6840f7f0b6df8200638 192.168.132.208:30471@30566 master - 0 1709546095505 1 connected 10923-16383
-4cc7fd15a841f081f8c956b0432f75baa170ea97 192.168.132.208:30969@30670 slave a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 0 1709546094000 2 connected
-e8cd1219f9d712f7a1002962625f4f6ab46e4a69 192.168.132.209:31741@30771 myself,master - 0 1709546091000 3 connected 0-5461
-c4db03ea65954e1c2ced6135b8622360b5bf6ca7 192.168.132.183:31176@32087 slave e8cd1219f9d712f7a1002962625f4f6ab46e4a69 0 1709546092000 3 connected
-a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 192.168.132.183:30550@31597 master - 0 1709546094511 2 connected 5462-10922
+			// A recovered cluster config: every node's valkey-assigned shard-id
+			// (including the distinct per-shard ids) must be preserved verbatim.
+			name: "6 nodes shard-ids preserved",
+			data: []byte(`f89575a0d78cdc25b5ea1886bb88f1d979026c7d 192.168.132.183:32295@31500,,tls-port=0,shard-id=aaaa1111 slave c8b765997335f66f892ca6840f7f0b6df8200638 0 1709546093510 1 connected
+c8b765997335f66f892ca6840f7f0b6df8200638 192.168.132.208:30471@30566,,tls-port=0,shard-id=aaaa1111 master - 0 1709546095505 1 connected 10923-16383
+4cc7fd15a841f081f8c956b0432f75baa170ea97 192.168.132.208:30969@30670,,tls-port=0,shard-id=bbbb2222 slave a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 0 1709546094000 2 connected
+e8cd1219f9d712f7a1002962625f4f6ab46e4a69 192.168.132.209:31741@30771,,tls-port=0,shard-id=cccc3333 myself,master - 0 1709546091000 3 connected 0-5461
+c4db03ea65954e1c2ced6135b8622360b5bf6ca7 192.168.132.183:31176@32087,,tls-port=0,shard-id=cccc3333 slave e8cd1219f9d712f7a1002962625f4f6ab46e4a69 0 1709546092000 3 connected
+a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 192.168.132.183:30550@31597,,tls-port=0,shard-id=bbbb2222 master - 0 1709546094511 2 connected 5462-10922
 vars currentEpoch 5 lastVoteEpoch 0`),
-				logger: logr.Discard(),
-				opts: &HealOptions{
-					Namespace:  "default",
-					PodName:    "drc-c6-0-0",
-					Workspace:  "/data",
-					TargetName: "nodes.conf",
-					Prefix:     "sync-",
-					ShardID:    "453e29079a2d30ac8122692ac4a1d1c9390acadf",
-					NodeFile:   "/data/nodes.conf",
-				},
-			},
-			want: []byte(`f89575a0d78cdc25b5ea1886bb88f1d979026c7d 192.168.132.183:32295@31500 slave c8b765997335f66f892ca6840f7f0b6df8200638 0 1709546093510 1 connected
-c8b765997335f66f892ca6840f7f0b6df8200638 192.168.132.208:30471@30566 master - 0 1709546095505 1 connected 10923-16383
-4cc7fd15a841f081f8c956b0432f75baa170ea97 192.168.132.208:30969@30670 slave a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 0 1709546094000 2 connected
-e8cd1219f9d712f7a1002962625f4f6ab46e4a69 192.168.132.209:31741@30771,,tls-port=0,shard-id=453e29079a2d30ac8122692ac4a1d1c9390acadf myself,master - 0 1709546091000 3 connected 0-5461
-c4db03ea65954e1c2ced6135b8622360b5bf6ca7 192.168.132.183:31176@32087,,tls-port=0,shard-id=453e29079a2d30ac8122692ac4a1d1c9390acadf slave e8cd1219f9d712f7a1002962625f4f6ab46e4a69 0 1709546092000 3 connected
-a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 192.168.132.183:30550@31597 master - 0 1709546094511 2 connected 5462-10922
+			want: []byte(`f89575a0d78cdc25b5ea1886bb88f1d979026c7d 192.168.132.183:32295@31500,,tls-port=0,shard-id=aaaa1111 slave c8b765997335f66f892ca6840f7f0b6df8200638 0 1709546093510 1 connected
+c8b765997335f66f892ca6840f7f0b6df8200638 192.168.132.208:30471@30566,,tls-port=0,shard-id=aaaa1111 master - 0 1709546095505 1 connected 10923-16383
+4cc7fd15a841f081f8c956b0432f75baa170ea97 192.168.132.208:30969@30670,,tls-port=0,shard-id=bbbb2222 slave a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 0 1709546094000 2 connected
+e8cd1219f9d712f7a1002962625f4f6ab46e4a69 192.168.132.209:31741@30771,,tls-port=0,shard-id=cccc3333 myself,master - 0 1709546091000 3 connected 0-5461
+c4db03ea65954e1c2ced6135b8622360b5bf6ca7 192.168.132.183:31176@32087,,tls-port=0,shard-id=cccc3333 slave e8cd1219f9d712f7a1002962625f4f6ab46e4a69 0 1709546092000 3 connected
+a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 192.168.132.183:30550@31597,,tls-port=0,shard-id=bbbb2222 master - 0 1709546094511 2 connected 5462-10922
 vars currentEpoch 5 lastVoteEpoch 0`),
-			wantErr: false,
 		},
 		{
-			name: "fix 7 nodes",
-			args: args{
-				ctx: context.Background(),
-				data: []byte(`14c4e058a702f5f3d8f1cd8b70cc3dd450f531ec 192.168.132.210:30541@32045,,tls-port=0,shard-id=78524c978001da077a73c07e1bde14f0eea5eb7d slave be0453515af6a6b9f6dbf96643604cbfc9517792 0 1709542562827 1 connected
-c426f0d5a3986d926497f3e925887e4db9ea4e12 192.168.132.183:32304@31460,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 slave 41631ee411f0c6b1c25742f867ebbb1a63856772 0 1709542563825 2 connected
-a1127158a63694800ac4e1187cc9fec7cae95dda 192.168.132.209:32287@31795,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 slave cce647d1c72bcac30aee07128c3aa1493405630e 0 1709542563000 0 connected
-cce647d1c72bcac30aee07128c3aa1493405630e 192.168.132.208:31513@30183,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 master - 0 1709542561000 0 connected 5462-10922
-41631ee411f0c6b1c25742f867ebbb1a63856772 192.168.132.209:30707@30244,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 master - 0 1709542563000 2 connected 10923-16383
-be0453515af6a6b9f6dbf96643604cbfc9517792 192.168.132.183:31200@32418,,tls-port=0,shard-id=78524c978001da077a73c07e1bde14f0eea5eb7d myself,master - 0 1709542561000 1 connected 0-5461
+			// A crash can leave a partial/garbage node line (no "connected" state
+			// or < 8 fields); such lines are dropped, valid lines are kept.
+			name: "drop crash-corrupted node line",
+			data: []byte(`c8b765997335f66f892ca6840f7f0b6df8200638 192.168.132.208:30471@30566,,tls-port=0,shard-id=aaaa1111 master - 0 1709546095505 1 connected 10923-16383
+deadbeef garbage line from crash
+a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 192.168.132.183:30550@31597,,tls-port=0,shard-id=bbbb2222 master - 0 1709546094511 2 connected 5462-10922
 vars currentEpoch 5 lastVoteEpoch 0`),
-				logger: logr.Discard(),
-				opts: &HealOptions{
-					Namespace:  "default",
-					PodName:    "drc-c7-0-0",
-					Workspace:  "/data",
-					TargetName: "nodes.conf",
-					Prefix:     "sync-",
-					ShardID:    "453e29079a2d30ac8122692ac4a1d1c9390acadf",
-					NodeFile:   "/data/nodes.conf",
-				},
-			},
-			want: []byte(`14c4e058a702f5f3d8f1cd8b70cc3dd450f531ec 192.168.132.210:30541@32045,,tls-port=0,shard-id=453e29079a2d30ac8122692ac4a1d1c9390acadf slave be0453515af6a6b9f6dbf96643604cbfc9517792 0 1709542562827 1 connected
-c426f0d5a3986d926497f3e925887e4db9ea4e12 192.168.132.183:32304@31460,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 slave 41631ee411f0c6b1c25742f867ebbb1a63856772 0 1709542563825 2 connected
-a1127158a63694800ac4e1187cc9fec7cae95dda 192.168.132.209:32287@31795,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 slave cce647d1c72bcac30aee07128c3aa1493405630e 0 1709542563000 0 connected
-cce647d1c72bcac30aee07128c3aa1493405630e 192.168.132.208:31513@30183,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 master - 0 1709542561000 0 connected 5462-10922
-41631ee411f0c6b1c25742f867ebbb1a63856772 192.168.132.209:30707@30244,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 master - 0 1709542563000 2 connected 10923-16383
-be0453515af6a6b9f6dbf96643604cbfc9517792 192.168.132.183:31200@32418,,tls-port=0,shard-id=453e29079a2d30ac8122692ac4a1d1c9390acadf myself,master - 0 1709542561000 1 connected 0-5461
+			want: []byte(`c8b765997335f66f892ca6840f7f0b6df8200638 192.168.132.208:30471@30566,,tls-port=0,shard-id=aaaa1111 master - 0 1709546095505 1 connected 10923-16383
+a8fa11eb3c3cc0c8115b8fe191d1e8ce92b857a5 192.168.132.183:30550@31597,,tls-port=0,shard-id=bbbb2222 master - 0 1709546094511 2 connected 5462-10922
 vars currentEpoch 5 lastVoteEpoch 0`),
-			wantErr: false,
 		},
 		{
-			name: "fix 7 myself,slave",
-			args: args{
-				ctx: context.Background(),
-				data: []byte(`14c4e058a702f5f3d8f1cd8b70cc3dd450f531ec 192.168.132.210:30541@32045,,tls-port=0,shard-id=78524c978001da077a73c07e1bde14f0eea5eb7d myself,slave be0453515af6a6b9f6dbf96643604cbfc9517792 0 1709542562827 1 connected
-c426f0d5a3986d926497f3e925887e4db9ea4e12 192.168.132.183:32304@31460,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 slave 41631ee411f0c6b1c25742f867ebbb1a63856772 0 1709542563825 2 connected
-a1127158a63694800ac4e1187cc9fec7cae95dda 192.168.132.209:32287@31795,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 slave cce647d1c72bcac30aee07128c3aa1493405630e 0 1709542563000 0 connected
-cce647d1c72bcac30aee07128c3aa1493405630e 192.168.132.208:31513@30183,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 master - 0 1709542561000 0 connected 5462-10922
-41631ee411f0c6b1c25742f867ebbb1a63856772 192.168.132.209:30707@30244,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 master - 0 1709542563000 2 connected 10923-16383
-be0453515af6a6b9f6dbf96643604cbfc9517792 192.168.132.183:31200@32418,,tls-port=0,shard-id=78524c978001da077a73c07e1bde14f0eea5eb7d master - 0 1709542561000 1 connected 0-5461
-vars currentEpoch 5 lastVoteEpoch 0`),
-				logger: logr.Discard(),
-				opts: &HealOptions{
-					Namespace:  "default",
-					PodName:    "drc-c7-0-0",
-					Workspace:  "/data",
-					TargetName: "nodes.conf",
-					Prefix:     "sync-",
-					ShardID:    "453e29079a2d30ac8122692ac4a1d1c9390acadf",
-					NodeFile:   "/data/nodes.conf",
-				},
-			},
-			want: []byte(`14c4e058a702f5f3d8f1cd8b70cc3dd450f531ec 192.168.132.210:30541@32045,,tls-port=0,shard-id=453e29079a2d30ac8122692ac4a1d1c9390acadf myself,slave be0453515af6a6b9f6dbf96643604cbfc9517792 0 1709542562827 1 connected
-c426f0d5a3986d926497f3e925887e4db9ea4e12 192.168.132.183:32304@31460,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 slave 41631ee411f0c6b1c25742f867ebbb1a63856772 0 1709542563825 2 connected
-a1127158a63694800ac4e1187cc9fec7cae95dda 192.168.132.209:32287@31795,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 slave cce647d1c72bcac30aee07128c3aa1493405630e 0 1709542563000 0 connected
-cce647d1c72bcac30aee07128c3aa1493405630e 192.168.132.208:31513@30183,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 master - 0 1709542561000 0 connected 5462-10922
-41631ee411f0c6b1c25742f867ebbb1a63856772 192.168.132.209:30707@30244,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 master - 0 1709542563000 2 connected 10923-16383
-be0453515af6a6b9f6dbf96643604cbfc9517792 192.168.132.183:31200@32418,,tls-port=0,shard-id=453e29079a2d30ac8122692ac4a1d1c9390acadf master - 0 1709542561000 1 connected 0-5461
-vars currentEpoch 5 lastVoteEpoch 0`),
-			wantErr: false,
-		},
-		{
-			name: "fix shard-id conflict with other shard",
-			args: args{
-				ctx: context.Background(),
-				data: []byte(`14c4e058a702f5f3d8f1cd8b70cc3dd450f531ec 192.168.132.210:30541@32045,,tls-port=0,shard-id=78524c978001da077a73c07e1bde14f0eea5eb7d slave be0453515af6a6b9f6dbf96643604cbfc9517792 0 1709542562827 1 connected
-c426f0d5a3986d926497f3e925887e4db9ea4e12 192.168.132.183:32304@31460,,tls-port=0,shard-id=da7d249987641fb2379cce47636469153c5e7e58 slave 41631ee411f0c6b1c25742f867ebbb1a63856772 0 1709542563825 2 connected
-a1127158a63694800ac4e1187cc9fec7cae95dda 192.168.132.209:32287@31795,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 slave cce647d1c72bcac30aee07128c3aa1493405630e 0 1709542563000 0 connected
-cce647d1c72bcac30aee07128c3aa1493405630e 192.168.132.208:31513@30183,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 master - 0 1709542561000 0 connected 5462-10922
-41631ee411f0c6b1c25742f867ebbb1a63856772 192.168.132.209:30707@30244,,tls-port=0,shard-id=1a7d249987641fb2379cce47636469153c5e7e58 master - 0 1709542563000 2 connected 10923-16383
-be0453515af6a6b9f6dbf96643604cbfc9517792 192.168.132.183:31200@32418,,tls-port=0,shard-id=78524c978001da077a73c07e1bde14f0eea5eb7d myself,master - 0 1709542561000 1 connected 0-5461
-vars currentEpoch 5 lastVoteEpoch 0`),
-				logger: logr.Discard(),
-				opts: &HealOptions{
-					Namespace:  "default",
-					PodName:    "drc-c7-0-0",
-					Workspace:  "/data",
-					TargetName: "nodes.conf",
-					Prefix:     "sync-",
-					ShardID:    "453e29079a2d30ac8122692ac4a1d1c9390acadf",
-					NodeFile:   "/data/nodes.conf",
-				},
-			},
-			want: []byte(`14c4e058a702f5f3d8f1cd8b70cc3dd450f531ec 192.168.132.210:30541@32045,,tls-port=0,shard-id=453e29079a2d30ac8122692ac4a1d1c9390acadf slave be0453515af6a6b9f6dbf96643604cbfc9517792 0 1709542562827 1 connected
-a1127158a63694800ac4e1187cc9fec7cae95dda 192.168.132.209:32287@31795,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 slave cce647d1c72bcac30aee07128c3aa1493405630e 0 1709542563000 0 connected
-cce647d1c72bcac30aee07128c3aa1493405630e 192.168.132.208:31513@30183,,tls-port=0,shard-id=a262f15901feff7a44f73a8d64210708909db3a5 master - 0 1709542561000 0 connected 5462-10922
-be0453515af6a6b9f6dbf96643604cbfc9517792 192.168.132.183:31200@32418,,tls-port=0,shard-id=453e29079a2d30ac8122692ac4a1d1c9390acadf myself,master - 0 1709542561000 1 connected 0-5461
-vars currentEpoch 5 lastVoteEpoch 0`),
-			wantErr: false,
+			// A truncated epoch line (currentEpoch only) is normalized to the
+			// full "currentEpoch N lastVoteEpoch N" form valkey expects.
+			name: "normalize truncated epoch line",
+			data: []byte(`c8b765997335f66f892ca6840f7f0b6df8200638 192.168.132.208:30471@30566,,tls-port=0,shard-id=aaaa1111 myself,master - 0 1709546095505 1 connected 0-16383
+vars currentEpoch 7`),
+			want: []byte(`c8b765997335f66f892ca6840f7f0b6df8200638 192.168.132.208:30471@30566,,tls-port=0,shard-id=aaaa1111 myself,master - 0 1709546095505 1 connected 0-16383
+vars currentEpoch 7 lastVoteEpoch 7`),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := fixClusterNodesConf(tt.args.data, tt.args.logger, tt.args.opts)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("portClusterNodesConf() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
+			got := fixClusterNodesConf(tt.data)
 			gotVals := strings.Split(string(got), "\n")
 			wantVals := strings.Split(string(tt.want), "\n")
 			sort.Strings(gotVals)
 			sort.Strings(wantVals)
 			if !reflect.DeepEqual(gotVals, wantVals) {
-				t.Errorf("portClusterNodesConf() = (%d)\n%s\n## want (%d)\n%s", len(got), strings.Join(gotVals, "\n"), len(tt.want), strings.Join(wantVals, "\n"))
+				t.Errorf("fixClusterNodesConf() = (%d)\n%s\n## want (%d)\n%s",
+					len(got), strings.Join(gotVals, "\n"), len(tt.want), strings.Join(wantVals, "\n"))
 			}
 		})
+	}
+}
+
+func Test_generateValkeyCluterNodeRecord(t *testing.T) {
+	got := string(generateValkeyCluterNodeRecord("default", "drc-c77-0-0"))
+
+	// Regression guard for valkey-io/valkey#2811: the seeded record must NOT
+	// carry a shard-id (a pre-written shard-id makes an empty replica look like
+	// an empty primary to peers and permanently breaks failover on valkey 9.1).
+	if strings.Contains(got, "shard-id") {
+		t.Fatalf("seeded node record must not contain a shard-id, got:\n%s", got)
+	}
+	// It must still seed a deterministic node-id so the pod keeps a stable
+	// identity across restarts.
+	if !strings.Contains(got, "myself,master") {
+		t.Fatalf("seeded node record must declare myself,master, got:\n%s", got)
+	}
+	nodeID := strings.Fields(got)[0]
+	if len(nodeID) != 40 {
+		t.Fatalf("expected a 40-char node-id, got %q", nodeID)
+	}
+	// Determinism: same namespace/pod -> same node-id.
+	if again := string(generateValkeyCluterNodeRecord("default", "drc-c77-0-0")); again != got {
+		t.Fatalf("node record not deterministic:\n%s\n!=\n%s", got, again)
 	}
 }

--- a/cmd/helper/commands/cluster/shutdown.go
+++ b/cmd/helper/commands/cluster/shutdown.go
@@ -168,12 +168,12 @@ func Shutdown(ctx context.Context, c *cli.Context, client *kubernetes.Clientset,
 					return nil
 				}
 
-				randInt := rand.Intn(50) + 1 // #nosec: ignore
+				randInt := rand.Intn(15) + 1 // #nosec: ignore
 				if i > 0 {
-					// only the first attempt needs the large anti-collision
-					// jitter; keep retries short so the termination grace
-					// period is spent failing over, not sleeping
-					randInt = rand.Intn(10) + 1 // #nosec: ignore
+					// only the first attempt needs the anti-collision jitter;
+					// keep retries short so the termination grace period is
+					// spent failing over, not sleeping
+					randInt = rand.Intn(5) + 1 // #nosec: ignore
 				}
 				duration := time.Duration(randInt) * time.Second
 				logger.Info(fmt.Sprintf("Wait for %s to escape failover conflict", duration))
@@ -192,9 +192,9 @@ func Shutdown(ctx context.Context, c *cli.Context, client *kubernetes.Clientset,
 				action := NoFailoverAction
 				if mastrNode.IsFailed() {
 					action = ForceFailoverAction
-				} else if i >= 3 {
-					// this node is terminating: if plain manual failovers keep
-					// failing (e.g. the replication link is still recovering
+				} else if i >= 1 {
+					// this node is terminating: if the plain manual failover
+					// failed (e.g. the replication link is still recovering
 					// from an ACL/password rollout), escalate to FORCE before
 					// the grace period expires — a forced promotion with the
 					// replica's current dataset beats dying unpromoted and
@@ -208,6 +208,8 @@ func Shutdown(ctx context.Context, c *cli.Context, client *kubernetes.Clientset,
 				return nil
 			}(); err == nil {
 				break
+			} else if i == 19 {
+				logger.Error(err, "CRITICAL: all failover attempts failed, shutting down an unpromoted master; the shard may lose data")
 			}
 			time.Sleep(time.Second * 5)
 		}

--- a/cmd/helper/commands/cluster/shutdown.go
+++ b/cmd/helper/commands/cluster/shutdown.go
@@ -169,6 +169,12 @@ func Shutdown(ctx context.Context, c *cli.Context, client *kubernetes.Clientset,
 				}
 
 				randInt := rand.Intn(50) + 1 // #nosec: ignore
+				if i > 0 {
+					// only the first attempt needs the large anti-collision
+					// jitter; keep retries short so the termination grace
+					// period is spent failing over, not sleeping
+					randInt = rand.Intn(10) + 1 // #nosec: ignore
+				}
 				duration := time.Duration(randInt) * time.Second
 				logger.Info(fmt.Sprintf("Wait for %s to escape failover conflict", duration))
 				time.Sleep(duration)
@@ -185,6 +191,14 @@ func Shutdown(ctx context.Context, c *cli.Context, client *kubernetes.Clientset,
 				mastrNode := nodes.Get(self.Id)
 				action := NoFailoverAction
 				if mastrNode.IsFailed() {
+					action = ForceFailoverAction
+				} else if i >= 3 {
+					// this node is terminating: if plain manual failovers keep
+					// failing (e.g. the replication link is still recovering
+					// from an ACL/password rollout), escalate to FORCE before
+					// the grace period expires — a forced promotion with the
+					// replica's current dataset beats dying unpromoted and
+					// losing the shard
 					action = ForceFailoverAction
 				}
 				if err := doValkeyFailover(ctx, valkeyClient, action, logger); err != nil {

--- a/cmd/helper/commands/helper.go
+++ b/cmd/helper/commands/helper.go
@@ -157,7 +157,16 @@ func NewOwnerReference(ctx context.Context, client *kubernetes.Clientset, namesp
 	if sts, err := client.AppsV1().StatefulSets(namespace).Get(ctx, name, metav1.GetOptions{}); err != nil {
 		return nil, err
 	} else {
-		return sts.OwnerReferences, nil
+		refs := make([]metav1.OwnerReference, 0, len(sts.OwnerReferences))
+		for _, ref := range sts.OwnerReferences {
+			// blockOwnerDeletion requires update permission on the owner's
+			// finalizers subresource when the OwnerReferencesPermissionEnforcement
+			// admission plugin is enabled, which the instance ServiceAccount does
+			// not have; background GC works without it.
+			ref.BlockOwnerDeletion = nil
+			refs = append(refs, ref)
+		}
+		return refs, nil
 	}
 }
 

--- a/internal/builder/clusterbuilder/statefulset.go
+++ b/internal/builder/clusterbuilder/statefulset.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clusterbuilder
 
 import (
-	"crypto/sha1" // #nosec
 	"fmt"
 
 	"github.com/chideat/valkey-operator/api/core"
@@ -168,13 +167,13 @@ func GenerateStatefulSet(inst types.ClusterInstance, index int) (*appsv1.Statefu
 
 	envs := buildEnvs(inst, headlessSvcName)
 
-	// persistent shard id
-	data := sha1.Sum(fmt.Appendf([]byte{}, "%s/%s", cluster.Namespace, stsName)) // #nosec
-	shardId := fmt.Sprintf("%x", data)
-	envs = append(envs, corev1.EnvVar{
-		Name:  "SHARD_ID",
-		Value: shardId,
-	})
+	// NOTE: the operator does not assign a shard-id. shard-id is a valkey-owned
+	// property that proves shared replication history; it is established by
+	// valkey itself when a node replicates its primary and is preserved across
+	// restarts via the ConfigMap-synced nodes.conf. Pre-writing a synthetic
+	// shard-id makes an empty replica appear to peers as an empty primary in
+	// the same shard, which valkey 9.1 (cluster stale-packet detection, see
+	// valkey-io/valkey#2811) then permanently rejects, breaking failover.
 	if container := buildValkeyDataInitContainer(cluster, opUser, envs); container != nil {
 		initContainers = append(initContainers, *container)
 	}

--- a/internal/webhook/v1alpha1/user_webhook.go
+++ b/internal/webhook/v1alpha1/user_webhook.go
@@ -228,6 +228,13 @@ func (v *UserCustomValidator) ValidateCreate(ctx context.Context, inst *valkeybu
 
 // ValidateUpdate implements admission.Validator so a webhook will be registered for the type User.
 func (v *UserCustomValidator) ValidateUpdate(ctx context.Context, oldInst, newInst *valkeybufredv1alpha1.User) (warns admission.Warnings, err error) {
+	// Objects being deleted only receive metadata updates (finalizer
+	// removal). Re-validating the spec here can deadlock deletion: once the
+	// referenced password secret is gone, the finalizer-removing update is
+	// rejected and the User (and its namespace) can never terminate.
+	if newInst != nil && newInst.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
 	ctx = context.WithValue(ctx, actionKey, "update")
 	return v.validate(ctx, oldInst, newInst)
 }

--- a/test/e2e/e2e_extra_testcases_test.go
+++ b/test/e2e/e2e_extra_testcases_test.go
@@ -346,16 +346,16 @@ func init() {
 			BeforeEach: newClusterExtraInstance,
 			Specs:      clusterExtraSpecs,
 		},
-		// Version upgrade: 8.1 → 8.2
+		// Version upgrade: 8.1 → 9.0
 		TestData{
-			When: "version upgrade 8.1 to 8.2",
+			When: "version upgrade 8.1 to 9.0",
 			BeforeEach: func(version string, accessType corev1.ServiceType) *rdsv1alpha1.Valkey {
 				if version != "8.1" {
 					return nil
 				}
 				inst := &rdsv1alpha1.Valkey{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cluster-upgrade-81-82",
+						Name:      "cluster-upgrade-81-90",
 						Namespace: testNamespace,
 					},
 					Spec: rdsv1alpha1.ValkeySpec{
@@ -394,8 +394,8 @@ func init() {
 					Name:   "deploy at 8.1 for upgrade test",
 					Labels: []string{"cluster", "upgrade"},
 					Func: func(ctx context.Context, inst *rdsv1alpha1.Valkey) {
-						if inst == nil || isVersionSkipped("8.2") {
-							Skip("upgrade test only runs for version 8.1 when 8.2 is available")
+						if inst == nil || isVersionSkipped("9.0") {
+							Skip("upgrade test only runs for version 8.1 when 9.0 is available")
 						}
 						Expect(k8sClient.Create(ctx, inst)).To(Succeed())
 						time.Sleep(time.Second * 30)
@@ -404,46 +404,47 @@ func init() {
 					},
 				},
 				{
-					Name:    "upgrade from 8.1 to 8.2 completes rolling update",
+					Name:    "upgrade from 8.1 to 9.0 completes rolling update",
 					Labels:  []string{"cluster", "upgrade"},
 					Timeout: 45 * time.Minute,
 					Func: func(ctx context.Context, inst *rdsv1alpha1.Valkey) {
-						if inst == nil || isVersionSkipped("8.2") {
-							Skip("upgrade test only runs for version 8.1 when 8.2 is available")
+						if inst == nil || isVersionSkipped("9.0") {
+							Skip("upgrade test only runs for version 8.1 when 9.0 is available")
 						}
-						patchInstanceVersion(ctx, inst, "8.2", 45*time.Minute)
+						patchInstanceVersion(ctx, inst, "9.0", 45*time.Minute)
 						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(inst), inst)).To(Succeed())
+						checkInstanceConfig(ctx, inst, valkeyDefaultUsername, "", "latency-tracking", "yes")
 						checkInstanceRead(ctx, inst, valkeyDefaultUsername, "")
 						checkInstanceWrite(ctx, inst, valkeyDefaultUsername, "")
 					},
 				},
 				{
-					Name:   "delete upgrade 8.1→8.2 instance",
+					Name:   "delete upgrade 8.1→9.0 instance",
 					Labels: []string{"cluster", "upgrade", "delete"},
 					Func: func(ctx context.Context, inst *rdsv1alpha1.Valkey) {
-						if inst == nil || isVersionSkipped("8.2") {
-							Skip("upgrade test only runs for version 8.1 when 8.2 is available")
+						if inst == nil || isVersionSkipped("9.0") {
+							Skip("upgrade test only runs for version 8.1 when 9.0 is available")
 						}
 						deleteInstance(ctx, inst)
 					},
 				},
 			},
 		},
-		// Version upgrade: 8.2 → 9.0
+		// Version upgrade: 9.0 → 9.1
 		TestData{
-			When: "version upgrade 8.2 to 9.0",
+			When: "version upgrade 9.0 to 9.1",
 			BeforeEach: func(version string, accessType corev1.ServiceType) *rdsv1alpha1.Valkey {
-				if version != "8.2" {
+				if version != "9.0" {
 					return nil
 				}
 				inst := &rdsv1alpha1.Valkey{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cluster-upgrade-82-90",
+						Name:      "cluster-upgrade-90-91",
 						Namespace: testNamespace,
 					},
 					Spec: rdsv1alpha1.ValkeySpec{
 						Arch:    core.ValkeyCluster,
-						Version: "8.2",
+						Version: "9.0",
 						Replicas: &rdsv1alpha1.ValkeyReplicas{
 							Shards:          3,
 							ReplicasOfShard: 2,
@@ -474,11 +475,11 @@ func init() {
 			},
 			Specs: []Spec{
 				{
-					Name:   "deploy at 8.2 for upgrade test",
+					Name:   "deploy at 9.0 for upgrade test",
 					Labels: []string{"cluster", "upgrade"},
 					Func: func(ctx context.Context, inst *rdsv1alpha1.Valkey) {
-						if inst == nil || isVersionSkipped("8.2") {
-							Skip("upgrade test only runs for version 8.2 when 8.2 is available")
+						if inst == nil || isVersionSkipped("9.1") {
+							Skip("upgrade test only runs for version 9.0 when 9.1 is available")
 						}
 						Expect(k8sClient.Create(ctx, inst)).To(Succeed())
 						time.Sleep(time.Second * 30)
@@ -487,14 +488,14 @@ func init() {
 					},
 				},
 				{
-					Name:    "upgrade from 8.2 to 9.0 completes rolling update",
+					Name:    "upgrade from 9.0 to 9.1 completes rolling update",
 					Labels:  []string{"cluster", "upgrade"},
 					Timeout: 45 * time.Minute,
 					Func: func(ctx context.Context, inst *rdsv1alpha1.Valkey) {
-						if inst == nil || isVersionSkipped("8.2") {
-							Skip("upgrade test only runs for version 8.2 when 8.2 is available")
+						if inst == nil || isVersionSkipped("9.1") {
+							Skip("upgrade test only runs for version 9.0 when 9.1 is available")
 						}
-						patchInstanceVersion(ctx, inst, "9.0", 45*time.Minute)
+						patchInstanceVersion(ctx, inst, "9.1", 45*time.Minute)
 						Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(inst), inst)).To(Succeed())
 						checkInstanceConfig(ctx, inst, valkeyDefaultUsername, "", "latency-tracking", "yes")
 						checkInstanceRead(ctx, inst, valkeyDefaultUsername, "")
@@ -502,11 +503,11 @@ func init() {
 					},
 				},
 				{
-					Name:   "delete upgrade 8.2→9.0 instance",
+					Name:   "delete upgrade 9.0→9.1 instance",
 					Labels: []string{"cluster", "upgrade", "delete"},
 					Func: func(ctx context.Context, inst *rdsv1alpha1.Valkey) {
-						if inst == nil || isVersionSkipped("8.2") {
-							Skip("upgrade test only runs for version 8.2 when 8.2 is available")
+						if inst == nil || isVersionSkipped("9.1") {
+							Skip("upgrade test only runs for version 9.0 when 9.1 is available")
 						}
 						deleteInstance(ctx, inst)
 					},

--- a/test/e2e/e2e_helpers_test.go
+++ b/test/e2e/e2e_helpers_test.go
@@ -112,14 +112,17 @@ func killPod(ctx context.Context, namespace, podName string) {
 	}
 	Expect(k8sClient.Delete(ctx, pod)).To(Succeed())
 
-	// Wait for the pod to be replaced (StatefulSet recreates it with a new UID)
+	// Wait for the pod to be replaced (StatefulSet recreates it with a new UID).
+	// A graceful master shutdown runs the pre-stop failover first (bounded by
+	// the 300s termination grace period), and the StatefulSet cannot recreate
+	// the pod until termination completes — so allow well beyond that.
 	Eventually(func() bool {
 		var p corev1.Pod
 		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(pod), &p); err != nil {
 			return true // pod is gone momentarily — counts as replaced
 		}
 		return p.UID != oldUID // new pod created
-	}).WithTimeout(time.Minute * 2).WithPolling(time.Second * 5).Should(BeTrue())
+	}).WithTimeout(time.Minute * 8).WithPolling(time.Second * 5).Should(BeTrue())
 }
 
 // skipIfVersionLessThan skips the current Ginkgo spec if inst.Spec.Version < minVersion.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -48,7 +48,7 @@ var (
 )
 
 var (
-	supportedVersions = []string{"7.2", "8.0", "8.1", "8.2", "9.0", "9.1"}
+	supportedVersions = []string{"7.2", "8.0", "8.1", "9.0", "9.1"}
 )
 
 func init() {
@@ -243,40 +243,42 @@ var _ = Describe("controller", Ordered, func() {
 		}
 
 		for _, param := range testParameters {
-			for _, cases := range clusterTestCases {
-				Context(cases.When, func() {
-					if cases.BeforeEach != nil {
-						BeforeEach(func() {
-							inst = cases.BeforeEach(param.Version, param.ServiceType)
-						})
-					}
-					for _, spec := range cases.Specs {
-						if spec.Skip {
-							continue
+			Context(fmt.Sprintf("version %s", param.Version), Label("v"+param.Version), func() {
+				for _, cases := range clusterTestCases {
+					Context(cases.When, func() {
+						if cases.BeforeEach != nil {
+							BeforeEach(func() {
+								inst = cases.BeforeEach(param.Version, param.ServiceType)
+							})
 						}
-						opts := []any{
-							func(ctx context.Context) {
-								spec.Func(ctx, inst)
-							},
+						for _, spec := range cases.Specs {
+							if spec.Skip {
+								continue
+							}
+							opts := []any{
+								func(ctx context.Context) {
+									spec.Func(ctx, inst)
+								},
+							}
+							if len(spec.Labels) > 0 {
+								opts = append(opts, Label(spec.Labels...))
+							}
+							if spec.Timeout > 0 {
+								opts = append(opts, SpecTimeout(spec.Timeout))
+							} else {
+								opts = append(opts, SpecTimeout(time.Minute*30))
+							}
+							It(spec.Name, opts...)
 						}
-						if len(spec.Labels) > 0 {
-							opts = append(opts, Label(spec.Labels...))
-						}
-						if spec.Timeout > 0 {
-							opts = append(opts, SpecTimeout(spec.Timeout))
-						} else {
-							opts = append(opts, SpecTimeout(time.Minute*30))
-						}
-						It(spec.Name, opts...)
-					}
 
-					if cases.AfterEach != nil {
-						AfterEach(func() {
-							cases.AfterEach(inst)
-						})
-					}
-				})
-			}
+						if cases.AfterEach != nil {
+							AfterEach(func() {
+								cases.AfterEach(inst)
+							})
+						}
+					})
+				}
+			})
 		}
 	})
 
@@ -301,40 +303,42 @@ var _ = Describe("controller", Ordered, func() {
 		}
 
 		for _, param := range testParameters {
-			for _, cases := range failoverTestCases {
-				Context(cases.When, func() {
-					if cases.BeforeEach != nil {
-						BeforeEach(func() {
-							inst = cases.BeforeEach(param.Version, param.ServiceType)
-						})
-					}
-					for _, spec := range cases.Specs {
-						if spec.Skip {
-							continue
+			Context(fmt.Sprintf("version %s", param.Version), Label("v"+param.Version), func() {
+				for _, cases := range failoverTestCases {
+					Context(cases.When, func() {
+						if cases.BeforeEach != nil {
+							BeforeEach(func() {
+								inst = cases.BeforeEach(param.Version, param.ServiceType)
+							})
 						}
-						opts := []any{
-							func(ctx context.Context) {
-								spec.Func(ctx, inst)
-							},
+						for _, spec := range cases.Specs {
+							if spec.Skip {
+								continue
+							}
+							opts := []any{
+								func(ctx context.Context) {
+									spec.Func(ctx, inst)
+								},
+							}
+							if len(spec.Labels) > 0 {
+								opts = append(opts, Label(spec.Labels...))
+							}
+							if spec.Timeout > 0 {
+								opts = append(opts, SpecTimeout(spec.Timeout))
+							} else {
+								opts = append(opts, SpecTimeout(time.Minute*30))
+							}
+							It(spec.Name, opts...)
 						}
-						if len(spec.Labels) > 0 {
-							opts = append(opts, Label(spec.Labels...))
-						}
-						if spec.Timeout > 0 {
-							opts = append(opts, SpecTimeout(spec.Timeout))
-						} else {
-							opts = append(opts, SpecTimeout(time.Minute*30))
-						}
-						It(spec.Name, opts...)
-					}
 
-					if cases.AfterEach != nil {
-						AfterEach(func() {
-							cases.AfterEach(inst)
-						})
-					}
-				})
-			}
+						if cases.AfterEach != nil {
+							AfterEach(func() {
+								cases.AfterEach(inst)
+							})
+						}
+					})
+				}
+			})
 		}
 	})
 
@@ -359,40 +363,42 @@ var _ = Describe("controller", Ordered, func() {
 		}
 
 		for _, param := range testParameters {
-			for _, cases := range replicationTestCases {
-				Context(cases.When, func() {
-					if cases.BeforeEach != nil {
-						BeforeEach(func() {
-							inst = cases.BeforeEach(param.Version, param.ServiceType)
-						})
-					}
-					for _, spec := range cases.Specs {
-						if spec.Skip {
-							continue
+			Context(fmt.Sprintf("version %s", param.Version), Label("v"+param.Version), func() {
+				for _, cases := range replicationTestCases {
+					Context(cases.When, func() {
+						if cases.BeforeEach != nil {
+							BeforeEach(func() {
+								inst = cases.BeforeEach(param.Version, param.ServiceType)
+							})
 						}
-						opts := []any{
-							func(ctx context.Context) {
-								spec.Func(ctx, inst)
-							},
+						for _, spec := range cases.Specs {
+							if spec.Skip {
+								continue
+							}
+							opts := []any{
+								func(ctx context.Context) {
+									spec.Func(ctx, inst)
+								},
+							}
+							if len(spec.Labels) > 0 {
+								opts = append(opts, Label(spec.Labels...))
+							}
+							if spec.Timeout > 0 {
+								opts = append(opts, SpecTimeout(spec.Timeout))
+							} else {
+								opts = append(opts, SpecTimeout(time.Minute*30))
+							}
+							It(spec.Name, opts...)
 						}
-						if len(spec.Labels) > 0 {
-							opts = append(opts, Label(spec.Labels...))
-						}
-						if spec.Timeout > 0 {
-							opts = append(opts, SpecTimeout(spec.Timeout))
-						} else {
-							opts = append(opts, SpecTimeout(time.Minute*30))
-						}
-						It(spec.Name, opts...)
-					}
 
-					if cases.AfterEach != nil {
-						AfterEach(func() {
-							cases.AfterEach(inst)
-						})
-					}
-				})
-			}
+						if cases.AfterEach != nil {
+							AfterEach(func() {
+								cases.AfterEach(inst)
+							})
+						}
+					})
+				}
+			})
 		}
 	})
 })

--- a/test/e2e/e2e_testdata_test.go
+++ b/test/e2e/e2e_testdata_test.go
@@ -247,15 +247,26 @@ func checkInstanceRead(ctx context.Context, inst *rdsv1alpha1.Valkey, username, 
 }
 
 func checkInstanceWrite(ctx context.Context, inst *rdsv1alpha1.Valkey, username, password string) {
-	client, err := newValkeyClient(ctx, inst, username, password)
-	Expect(err).To(Succeed())
-	defer client.Close()
-
 	By("checking write valkey")
-	for i := range 1000 {
-		key := fmt.Sprintf("key-%d", i)
-		Expect(client.Do(ctx, client.B().Set().Key(key).Value(key).Build()).Error()).To(Succeed())
-	}
+	// Mirror checkInstanceRead: rebuild the client and retry the whole loop so a
+	// transient cluster-routing gap (e.g. "the slot has no valkey node" while an
+	// ACL change churns connections) does not fail the spec — the cluster is
+	// healthy and the write succeeds once the client's slot map settles.
+	Eventually(func() error {
+		client, err := newValkeyClient(ctx, inst, username, password)
+		if err != nil {
+			return fmt.Errorf("create client failed: %w", err)
+		}
+		defer client.Close()
+
+		for i := range 1000 {
+			key := fmt.Sprintf("key-%d", i)
+			if err := client.Do(ctx, client.B().Set().Key(key).Value(key).Build()).Error(); err != nil {
+				return fmt.Errorf("set %s failed: %w", key, err)
+			}
+		}
+		return nil
+	}).WithTimeout(time.Minute * 5).WithPolling(time.Second * 5).Should(Succeed())
 }
 
 type Spec struct {

--- a/test/e2e/e2e_testdata_test.go
+++ b/test/e2e/e2e_testdata_test.go
@@ -193,15 +193,29 @@ func newValkeyClient(ctx context.Context, inst *rdsv1alpha1.Valkey, username, pa
 	if err != nil {
 		return nil, err
 	}
-	// The cluster client fetches its slot map lazily; right after a topology
-	// change (e.g. ACL-triggered reconnects during user create/delete) a slot
-	// can momentarily map to no node ("the slot has no valkey node"). Probe a
-	// spread of keys until routing works so callers don't observe that
-	// transient gap; a failed probe forces the client to refresh its slot map.
+	// A cluster client fetches its slot map when it is constructed. If the
+	// cluster is still settling — right after a config-propagation pod restart,
+	// or ACL-triggered reconnects during user create/delete — that snapshot can
+	// be missing slots. Every later command on an uncovered slot then fails with
+	// "the slot has no valkey node", and the client does not recover on its own:
+	// it treats the slot as legitimately empty and never re-fetches. So wait
+	// until the cluster reports full slot coverage (cluster_state:ok) and routing
+	// works across a spread of slots, rebuilding the client between attempts so
+	// it captures a complete topology before any caller uses it.
 	if inst.Spec.Arch == core.ValkeyCluster {
-		deadline := time.Now().Add(time.Minute)
+		deadline := time.Now().Add(time.Minute * 3)
 		for {
 			probeErr := func() error {
+				// cluster_state flips to ok only once all 16384 slots are
+				// assigned, so it is a reliable "fully settled" signal. CLUSTER
+				// INFO is unkeyed and works even while the slot map is partial.
+				info, e := c.Do(ctx, c.B().ClusterInfo().Build()).ToString()
+				if e != nil {
+					return e
+				}
+				if !strings.Contains(info, "cluster_state:ok") {
+					return fmt.Errorf("cluster not fully settled: %s", strings.SplitN(info, "\r\n", 2)[0])
+				}
 				for i := range 16 {
 					key := fmt.Sprintf("e2e-routable-probe-%d", i)
 					if e := c.Do(ctx, c.B().Get().Key(key).Build()).Error(); e != nil && !valkey.IsValkeyNil(e) {
@@ -217,7 +231,13 @@ func newValkeyClient(ctx context.Context, inst *rdsv1alpha1.Valkey, username, pa
 				c.Close()
 				return nil, probeErr
 			}
+			// Rebuild so the next attempt re-fetches the (now more complete) slot
+			// map; a stale client will not re-fetch a slot it believes is empty.
+			c.Close()
 			time.Sleep(time.Second)
+			if c, err = valkey.NewClient(options); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return c, nil

--- a/test/e2e/e2e_testdata_test.go
+++ b/test/e2e/e2e_testdata_test.go
@@ -189,7 +189,38 @@ func newValkeyClient(ctx context.Context, inst *rdsv1alpha1.Valkey, username, pa
 	} else if inst.Spec.Arch == core.ValkeyCluster {
 		options.ShuffleInit = true
 	}
-	return valkey.NewClient(options)
+	c, err := valkey.NewClient(options)
+	if err != nil {
+		return nil, err
+	}
+	// The cluster client fetches its slot map lazily; right after a topology
+	// change (e.g. ACL-triggered reconnects during user create/delete) a slot
+	// can momentarily map to no node ("the slot has no valkey node"). Probe a
+	// spread of keys until routing works so callers don't observe that
+	// transient gap; a failed probe forces the client to refresh its slot map.
+	if inst.Spec.Arch == core.ValkeyCluster {
+		deadline := time.Now().Add(time.Minute)
+		for {
+			probeErr := func() error {
+				for i := range 16 {
+					key := fmt.Sprintf("e2e-routable-probe-%d", i)
+					if e := c.Do(ctx, c.B().Get().Key(key).Build()).Error(); e != nil && !valkey.IsValkeyNil(e) {
+						return e
+					}
+				}
+				return nil
+			}()
+			if probeErr == nil {
+				break
+			}
+			if time.Now().After(deadline) {
+				c.Close()
+				return nil, probeErr
+			}
+			time.Sleep(time.Second)
+		}
+	}
+	return c, nil
 }
 
 func checkInstanceRead(ctx context.Context, inst *rdsv1alpha1.Valkey, username, password string) {


### PR DESCRIPTION
These are the fixes and e2e coverage that came out of investigating a cluster data-loss on valkey 9.1. Grouped by concern.

## 🔴 Cluster data loss

- **Stop pre-writing a synthetic shard-id for cluster nodes.** The in-pod helper seeded `nodes.conf` with a deterministic per-shard SHA1 `shard-id`. Once valkey's [#2811](https://github.com/valkey-io/valkey/issues/2811) two-sided stale-message check is present (valkey 9.1.0, and backported to 8.0.10 / 8.1.9 / 9.0.5), a replica's first post-`REPLICATE` role announcement enters the same-shard "stale" branch and is dropped **permanently** — peers then see replicas as empty primaries, failover elections collect 0 votes (`Failover auth denied … it is a primary node`), and killing a master **wipes its shard**. Fix: seed a deterministic node-id only and let valkey adopt the master's shard on `REPLICATE`; the helper preserves valkey's real shard-ids verbatim on recovery.
- **Do not set `blockOwnerDeletion` on synced ConfigMap owner refs.** On clusters running the `OwnerReferencesPermissionEnforcement` admission plugin, the helper's `sync-<pod>` ConfigMap create/update is forbidden (`cannot set blockOwnerDeletion`), so `nodes.conf` never persists and restarted nodes rejoin slowly — the pre-stop failover then finds no candidate and masters shut down unpromoted, losing data on rolling restarts. Background GC does not need `blockOwnerDeletion`, so clear it.

## Graceful-shutdown failover

- Escalate to a FORCE failover when a graceful master shutdown stalls.
- Give cluster failover elections time to collect votes before giving up.
- Pace the rebalance/failover within the pod termination grace period.

## Webhook

- Do not re-validate `User` objects that are being deleted — otherwise a `User` (and its namespace) gets stuck `Terminating` once the referenced password secret is already gone.

## e2e

- Cover all supported valkey versions (7.2 / 8.0 / 8.1 / 9.0 / 9.1) plus the cross-version upgrade chains.
- Allow the killPod replacement wait to tolerate a graceful master handoff.
- Harden the cluster client against transient slot-map gaps (`the slot has no valkey node`): a routability probe, a whole-write-loop retry, and a full-slot-coverage (`cluster_state:ok`) gate that rebuilds the client so it captures a complete topology before use.

---

**Validation:** the full 277-spec e2e suite passed **243 Passed | 0 Failed | 34 Skipped** on both amd64 (K8s 1.34) and arm64 (K8s 1.33) — all five versions × cluster / failover / replica, including the cluster kill-master resilience specs that previously lost data on 9.1.