### PR TITLE
fix: cluster arch on ClusterIP access, and stranded password secret finalizer

### DIFF
--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -207,14 +207,14 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		if secret.GetLabels() == nil {
 			secret.SetLabels(map[string]string{})
 		}
+		// NOTE: the finalizer is deliberately not added here. It is added only
+		// once the user exists on the instance, see below.
 		if secret.Labels[builder.InstanceNameLabelKey] != vkName ||
-			len(secret.GetOwnerReferences()) == 0 || secret.OwnerReferences[0].UID != instance.GetUID() ||
-			controllerutil.ContainsFinalizer(secret, UserFinalizer) {
+			len(secret.GetOwnerReferences()) == 0 || secret.OwnerReferences[0].UID != instance.GetUID() {
 
 			secret.Labels[builder.ManagedByLabelKey] = config.AppName
 			secret.Labels[builder.InstanceNameLabelKey] = vkName
 			secret.OwnerReferences = util.BuildOwnerReferences(&instance)
-			controllerutil.AddFinalizer(secret, UserFinalizer)
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				return r.Update(ctx, secret)
 			}); err != nil {
@@ -260,6 +260,34 @@ func (r *UserReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		if err := r.updateUser(ctx, &instance); err != nil {
 			logger.Error(err, "update finalizer user failed")
 			return ctrl.Result{}, err
+		}
+	}
+
+	// The secret finalizer holds the password until the user has been dropped from
+	// the instance, so it is only required once that user exists, and only after the
+	// User above carries its own finalizer. A secret finalizer that is set while the
+	// User has none is never reclaimed: the User is deleted without ever running the
+	// cleanup path above, stranding the secret and blocking namespace deletion.
+	for _, name := range instance.Spec.PasswordSecrets {
+		if name == "" {
+			continue
+		}
+		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			secret := &corev1.Secret{}
+			if err := r.Get(ctx, types.NamespacedName{Namespace: instance.Namespace, Name: name}, secret); err != nil {
+				return err
+			}
+			if !controllerutil.AddFinalizer(secret, UserFinalizer) {
+				return nil
+			}
+			return r.Update(ctx, secret)
+		}); err != nil {
+			if errors.IsNotFound(err) {
+				logger.Info("secret not found, skip add finalizer", "name", name)
+				continue
+			}
+			logger.Error(err, "add finalizer to secret failed", "secret name", name)
+			return ctrl.Result{RequeueAfter: time.Second * 5}, nil
 		}
 	}
 

--- a/internal/ops/cluster/actor/actor_ensure_resource.go
+++ b/internal/ops/cluster/actor/actor_ensure_resource.go
@@ -370,7 +370,9 @@ func (a *actorEnsureResource) ensureService(ctx context.Context, cluster types.C
 		if err := a.ensureValkeyNodePortService(ctx, cluster, logger); err != nil {
 			return err
 		}
-	case corev1.ServiceTypeLoadBalancer:
+	case corev1.ServiceTypeLoadBalancer, corev1.ServiceTypeClusterIP:
+		// every node needs a pod binded service: the init container resolves its
+		// announce address from it before valkey starts.
 		if ret := a.ensureValkeyPodService(ctx, cluster, logger); ret != nil {
 			return ret
 		}
@@ -613,10 +615,6 @@ func (a *actorEnsureResource) ensureValkeyPodService(ctx context.Context, cluste
 
 func (a *actorEnsureResource) cleanUselessService(ctx context.Context, cluster types.ClusterInstance, logger logr.Logger) *actor.ActorResult {
 	cr := cluster.Definition()
-	if cr.Spec.Access.ServiceType != corev1.ServiceTypeLoadBalancer && cr.Spec.Access.ServiceType != corev1.ServiceTypeNodePort {
-		return nil
-	}
-
 	labels := clusterbuilder.GenerateClusterLabels(cr.Name, nil)
 	services, ret := a.fetchAllPodBindedServices(ctx, cr.Namespace, labels)
 	if ret != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -49,6 +49,15 @@ var (
 
 var (
 	supportedVersions = []string{"7.2", "8.0", "8.1", "9.0", "9.1"}
+
+	// Access modes every version is exercised against. ClusterIP is the default
+	// an instance gets when access.serviceType is unset, NodePort the exposed
+	// path; the two reach the instance through different service wiring, so a
+	// regression in one is invisible from the other.
+	testedServiceTypes = []corev1.ServiceType{
+		corev1.ServiceTypeClusterIP,
+		corev1.ServiceTypeNodePort,
+	}
 )
 
 func init() {
@@ -233,17 +242,20 @@ var _ = Describe("controller", Ordered, func() {
 			inst *rdsv1alpha1.Valkey
 		)
 
-		// Generate test parameters for all supported versions with ClusterIP service type
+		// Generate test parameters for all supported versions against each access mode
 		testParameters := []TestParameter{}
 		for _, version := range supportedVersions {
-			testParameters = append(testParameters, TestParameter{
-				Version:     version,
-				ServiceType: corev1.ServiceTypeNodePort,
-			})
+			for _, serviceType := range testedServiceTypes {
+				testParameters = append(testParameters, TestParameter{
+					Version:     version,
+					ServiceType: serviceType,
+				})
+			}
 		}
 
 		for _, param := range testParameters {
-			Context(fmt.Sprintf("version %s", param.Version), Label("v"+param.Version), func() {
+			Context(fmt.Sprintf("version %s access %s", param.Version, param.ServiceType),
+				Label("v"+param.Version, string(param.ServiceType)), func() {
 				for _, cases := range clusterTestCases {
 					Context(cases.When, func() {
 						if cases.BeforeEach != nil {
@@ -293,17 +305,20 @@ var _ = Describe("controller", Ordered, func() {
 			inst *rdsv1alpha1.Valkey
 		)
 
-		// Generate test parameters for all supported versions with ClusterIP service type
+		// Generate test parameters for all supported versions against each access mode
 		testParameters := []TestParameter{}
 		for _, version := range supportedVersions {
-			testParameters = append(testParameters, TestParameter{
-				Version:     version,
-				ServiceType: corev1.ServiceTypeNodePort,
-			})
+			for _, serviceType := range testedServiceTypes {
+				testParameters = append(testParameters, TestParameter{
+					Version:     version,
+					ServiceType: serviceType,
+				})
+			}
 		}
 
 		for _, param := range testParameters {
-			Context(fmt.Sprintf("version %s", param.Version), Label("v"+param.Version), func() {
+			Context(fmt.Sprintf("version %s access %s", param.Version, param.ServiceType),
+				Label("v"+param.Version, string(param.ServiceType)), func() {
 				for _, cases := range failoverTestCases {
 					Context(cases.When, func() {
 						if cases.BeforeEach != nil {
@@ -353,17 +368,20 @@ var _ = Describe("controller", Ordered, func() {
 			inst *rdsv1alpha1.Valkey
 		)
 
-		// Generate test parameters for all supported versions with ClusterIP service type
+		// Generate test parameters for all supported versions against each access mode
 		testParameters := []TestParameter{}
 		for _, version := range supportedVersions {
-			testParameters = append(testParameters, TestParameter{
-				Version:     version,
-				ServiceType: corev1.ServiceTypeNodePort,
-			})
+			for _, serviceType := range testedServiceTypes {
+				testParameters = append(testParameters, TestParameter{
+					Version:     version,
+					ServiceType: serviceType,
+				})
+			}
 		}
 
 		for _, param := range testParameters {
-			Context(fmt.Sprintf("version %s", param.Version), Label("v"+param.Version), func() {
+			Context(fmt.Sprintf("version %s access %s", param.Version, param.ServiceType),
+				Label("v"+param.Version, string(param.ServiceType)), func() {
 				for _, cases := range replicationTestCases {
 					Context(cases.When, func() {
 						if cases.BeforeEach != nil {

--- a/test/e2e/e2e_testdata_test.go
+++ b/test/e2e/e2e_testdata_test.go
@@ -38,6 +38,20 @@ var (
 	valkeyDefaultSenPassword, _ = security.GeneratePassword(12)
 )
 
+// accessSuffix distinguishes instance names per access mode. Each version is
+// deployed once per mode, so without it the two runs would collide on the same
+// name in the same namespace.
+func accessSuffix(serviceType corev1.ServiceType) string {
+	switch serviceType {
+	case corev1.ServiceTypeNodePort:
+		return "np"
+	case corev1.ServiceTypeLoadBalancer:
+		return "lb"
+	default:
+		return "cip"
+	}
+}
+
 func generateValkeyUserInstanceName(inst *rdsv1alpha1.Valkey, username string) string {
 	switch inst.Spec.Arch {
 	case core.ValkeyCluster:
@@ -309,7 +323,7 @@ var clusterTestCases = []TestData{
 		BeforeEach: func(version string, accessType corev1.ServiceType) *rdsv1alpha1.Valkey {
 			inst := &rdsv1alpha1.Valkey{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("cluster-valkey-%s", strings.ReplaceAll(version, ".", "-")),
+					Name:      fmt.Sprintf("cluster-valkey-%s-%s", strings.ReplaceAll(version, ".", "-"), accessSuffix(accessType)),
 					Namespace: testNamespace,
 				},
 				Spec: rdsv1alpha1.ValkeySpec{
@@ -520,7 +534,7 @@ var failoverTestCases = []TestData{
 		BeforeEach: func(version string, accessType corev1.ServiceType) *rdsv1alpha1.Valkey {
 			inst := &rdsv1alpha1.Valkey{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("failover-valkey-%s", strings.ReplaceAll(version, ".", "-")),
+					Name:      fmt.Sprintf("failover-valkey-%s-%s", strings.ReplaceAll(version, ".", "-"), accessSuffix(accessType)),
 					Namespace: testNamespace,
 				},
 				Spec: rdsv1alpha1.ValkeySpec{
@@ -732,7 +746,7 @@ var replicationTestCases = []TestData{
 		BeforeEach: func(version string, accessType corev1.ServiceType) *rdsv1alpha1.Valkey {
 			inst := &rdsv1alpha1.Valkey{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      fmt.Sprintf("replica-valkey-%s", strings.ReplaceAll(version, ".", "-")),
+					Name:      fmt.Sprintf("replica-valkey-%s-%s", strings.ReplaceAll(version, ".", "-"), accessSuffix(accessType)),
 					Namespace: testNamespace,
 				},
 				Spec: rdsv1alpha1.ValkeySpec{


### PR DESCRIPTION
Two independent bugs found while running a version-coverage check against a build of this operator. Both are long-standing on `main` and both are verified against a live cluster.

They're unrelated but share a discovery path and are each a one-file change, so they're bundled here — happy to split into two PRs if you'd prefer.

## 1. Cluster arch never starts when `access.serviceType` is ClusterIP

`ensureService` switches on `Access.ServiceType` with cases for `NodePort` and `LoadBalancer` only. `ServiceType` is a closed enum (`+kubebuilder:validation:Enum=NodePort;LoadBalancer;ClusterIP`) defaulted to `ClusterIP`, so the default path matches **no case** and `ensureValkeyPodService` never runs.

The per-pod service is therefore never created. `init_cluster.sh` unconditionally runs `valkey-helper cluster expose`, and `Access()` requires a service named after the pod to resolve its announce address — so it exits 1 and every node sits in `Init:CrashLoopBackOff`:

```
Expose  get service failed  {"target": "ns/drc-<name>-0-0", "error": "services \"drc-<name>-0-0\" not found"}
Expose  expose node port failed  {"error": "services \"drc-<name>-0-0\" not found"}
```

Net effect: **cluster arch only ever comes up on NodePort or LoadBalancer.** The default in-cluster ClusterIP mode has never worked. That looks unintended rather than unsupported — `Access()` has an explicit non-NodePort path that sets `announceIp = pod.Status.PodIP`.

Failover already gets this right — its `ensureService` sends everything except NodePort-with-ports to `ensureValkeyPodService`, which is why failover+ClusterIP works. This change aligns cluster with that behaviour.

`cleanUselessService`'s LoadBalancer/NodePort guard is dropped for the same reason: all three service types now have pod binded services, so scale-down must reclaim them for ClusterIP too. `fetchAllPodBindedServices` already filters to services carrying a pod-name selector, so headless and instance services are unaffected — and failover's equivalent has no such guard either.

**Why CI doesn't catch it:** all three arch suites in `test/e2e/e2e_test.go` are commented `// Generate test parameters for all supported versions with ClusterIP service type` but then build their parameters with `ServiceType: corev1.ServiceTypeNodePort`. Only the working path is ever exercised. Worth fixing separately — it would also give cluster arch real ClusterIP coverage.

## 2. Password secret stranded, wedging namespace deletion

Asymmetric finalizer ordering in `user_controller.go`:

- the **secret** gets `buf.red/user-finalizer` at line 217, while merely reconciling the password secret
- the **User** gets its finalizer at line 259, only after `Handler.Do` succeeds

For an instance that never becomes ready these never balance. `Handler.Do` returns `instance is not ready` and requeues at line 240, so the secret carries a finalizer while the User carries none.

Deleting the namespace then strands the secret: the User has no finalizer, so it's removed immediately — taking with it the only controller that would ever run the cleanup path that drops the secret's finalizer. Nothing watches the secret afterward, so the namespace stays in `Terminating` forever:

```
NamespaceContentRemaining:   Some resources are remaining: secrets. has 1 resource instances
NamespaceFinalizersRemaining: buf.red/user-finalizer in 1 resource instances
```

The finalizer exists to keep the password readable until the user is dropped from the instance, so it isn't needed until that user exists. It's now added once the User reaches Ready, and **only after the User itself is finalized**.

That ordering is the invariant, and it's the load-bearing part of the fix: a secret finalizer set while the User has none is unreclaimable, whereas a User finalizer with no secret finalizer is safe — the cleanup path reclaims every secret it owns. So partial failure degrades to safe rather than wedged, and an instance that never becomes ready ends with no finalizers at all and is GC'd normally.

Also drops the `ContainsFinalizer` clause from the secret update condition — it existed to trigger the finalizer add, and with that moved out it would otherwise fire an `r.Update` on every reconcile once the finalizer was present.

## Testing

`go build ./...`, `go vet`, and the unit suite (incl. envtest-backed controller suites) pass on this branch.

Both fixes verified live on a 4-node cluster:

- **ClusterIP cluster:** a 3-shard instance crash-looped in init on the unfixed build; with this change the same spec reaches Ready in ~90s with `cluster_state:ok`, 16384 slots assigned, 3 nodes announcing their pod IPs, and the three `drc-*` per-pod services created by the operator itself.
- **Finalizer:** an instance left permanently unschedulable produces its acl secret with `finalizers=[]` (previously `["buf.red/user-finalizer"]`), and deleting the namespace now completes in ~60s instead of hanging indefinitely.
- No regression: 7.2 / 8.0 / 8.1 / 9.0 / 9.1 all still reach Ready on failover arch.

## Note

Secrets already stranded by an earlier operator still need the finalizer removed by hand — nothing watches them once their User is gone:

```sh
kubectl -n <ns> patch secret <name> --type=merge -p '{"metadata":{"finalizers":null}}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
